### PR TITLE
.NET Fx compatibility in MSBuild files for VS users

### DIFF
--- a/twodog/build/2dog.targets
+++ b/twodog/build/2dog.targets
@@ -31,7 +31,9 @@
     <ItemGroup Condition="'$(GodotProjectDir)' != ''">
         <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
             <_Parameter1>GodotProjectDir</_Parameter1>
-            <_Parameter2>$([System.IO.Path]::GetFullPath('$(GodotProjectDir)', '$(MSBuildProjectDirectory)'))</_Parameter2>
+            <!-- We use the single-parameter overload of GetFullPath with Combine to be .NET Framework-compatible -->
+            <!-- This is important for VS users, where processes are still hosted in .NET Fx -->
+            <_Parameter2>$([System.IO.Path]::GetFullPath($([System.IO.Path]::Combine('$(MSBuildProjectDirectory)', '$(GodotProjectDir)'))))</_Parameter2>
         </AssemblyAttribute>
     </ItemGroup>
 


### PR DESCRIPTION
VS can't load a 2dog project because

> error  : Invalid static method invocation syntax: "[System.IO.Path]::GetFullPath('$(GodotProjectDir)', '$(MSBuildProjectDirectory)')". Method 'System.IO.Path.GetFullPath' not found. Static method invocation should be of the form: $([FullTypeName]::Method()), e.g. $([System.IO.Path]::Combine(a, b)). Check that all parameters are defined, are of the correct type, and are specified in the right order.

Unfortunately they still host every process in .NET Fx and that means the 2-parameter overload of `GetFullPath` is not available (at least this is my theory). Fortunately, with a small change back-compat can be achieved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build system path resolution to enhance compatibility across different development environments and configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->