### PR TITLE
Assembly loader

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <TwoDogVersion>0.1.15-pre</TwoDogVersion>
+        <TwoDogVersion>0.1.16-pre</TwoDogVersion>
         <!-- Native platform package version. Bump only when godot submodule changes. -->
         <NativesVersion>0.1.11-pre</NativesVersion>
         <!-- Allow running on any .NET 8+ runtime (8, 9, 10, ...) -->

--- a/twodog.xunit/AssemblyPreloader.cs
+++ b/twodog.xunit/AssemblyPreloader.cs
@@ -1,0 +1,114 @@
+using System.Reflection;
+using System.Runtime.Loader;
+
+namespace twodog.xunit;
+
+/// <summary>
+/// Handles pre-loading game assemblies into the Default AssemblyLoadContext before Godot starts.
+/// This prevents type identity issues where the same type exists in multiple load contexts.
+/// </summary>
+internal static class AssemblyPreloader
+{
+    /// <summary>
+    /// Discovers and pre-loads game assemblies referenced by the test project.
+    /// Must be called BEFORE Engine.Start() to ensure assemblies load into Default context
+    /// rather than Godot's PluginLoadContext.
+    /// </summary>
+    /// <param name="projectPath">Path to the Godot project directory</param>
+    public static void PreloadGameAssemblies(string projectPath)
+    {
+        try
+        {
+            var gameAssemblyPaths = FindGameAssemblies(projectPath);
+            if (gameAssemblyPaths.Any())
+            {
+                Console.WriteLine($"[AssemblyPreloader] Found {gameAssemblyPaths.Count()} game assembly(ies)");
+
+                foreach (var gameAssemblyPath in gameAssemblyPaths)
+                {
+                    // Check if already loaded in Default context
+                    var assemblyName = AssemblyName.GetAssemblyName(gameAssemblyPath);
+                    var existingAssembly = AssemblyLoadContext.Default.Assemblies
+                        .FirstOrDefault(a => string.Equals(a.GetName().Name, assemblyName.Name, StringComparison.OrdinalIgnoreCase));
+
+                    if (existingAssembly != null)
+                    {
+                        Console.WriteLine($"[AssemblyPreloader] Assembly '{assemblyName.Name}' already loaded in Default context");
+                        continue;
+                    }
+
+                    // Load into Default context
+                    var assembly = Assembly.LoadFrom(gameAssemblyPath);
+                    Console.WriteLine($"[AssemblyPreloader] Pre-loaded assembly '{assembly.GetName().Name}' into Default context");
+                }
+            }
+            else
+            {
+                Console.WriteLine("[AssemblyPreloader] No game assemblies found to pre-load");
+            }
+        }
+        catch (Exception ex)
+        {
+            // Don't fail the test if pre-loading fails - just log and continue
+            Console.WriteLine($"[AssemblyPreloader] Warning: Failed to pre-load game assemblies: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Finds all compiled game assemblies in the Godot project's output directory.
+    /// Searches through different build configurations (Debug/Release/Editor).
+    /// Returns assemblies sorted alphabetically for deterministic loading order.
+    /// </summary>
+    private static IEnumerable<string> FindGameAssemblies(string projectPath)
+    {
+        // Godot builds assemblies to .godot/mono/temp/bin/{Configuration}/
+        var monoTempBin = Path.Combine(projectPath, ".godot", "mono", "temp", "bin");
+        if (!Directory.Exists(monoTempBin))
+        {
+            Console.WriteLine($"[AssemblyPreloader] Mono temp bin directory not found: {monoTempBin}");
+            return Enumerable.Empty<string>();
+        }
+
+        // Try configurations in order: Debug, Release, Editor
+        var configurations = new[] { "Debug", "Release", "Editor" };
+
+        foreach (var config in configurations)
+        {
+            var configPath = Path.Combine(monoTempBin, config);
+            if (!Directory.Exists(configPath))
+                continue;
+
+            var candidateDlls = Directory.GetFiles(configPath, "*.dll")
+                .Where(f => !IsSystemOrGodotAssembly(f))
+                .OrderBy(f => Path.GetFileName(f), StringComparer.Ordinal)
+                .ToArray();
+
+            if (candidateDlls.Length > 0)
+            {
+                if (candidateDlls.Length > 1)
+                {
+                    Console.WriteLine($"[AssemblyPreloader] Multiple game assemblies found in {config} (will pre-load all in alphabetical order):");
+                    foreach (var dll in candidateDlls)
+                        Console.WriteLine($"  - {Path.GetFileName(dll)}");
+                }
+
+                return candidateDlls;
+            }
+        }
+
+        return Enumerable.Empty<string>();
+    }
+
+    /// <summary>
+    /// Filters out system and Godot framework assemblies to find user game assemblies.
+    /// </summary>
+    private static bool IsSystemOrGodotAssembly(string path)
+    {
+        var fileName = Path.GetFileName(path);
+        return fileName.StartsWith("GodotSharp", StringComparison.OrdinalIgnoreCase) ||
+               fileName.Equals("GodotPlugins.dll", StringComparison.OrdinalIgnoreCase) ||
+               fileName.StartsWith("System.", StringComparison.OrdinalIgnoreCase) ||
+               fileName.StartsWith("Microsoft.", StringComparison.OrdinalIgnoreCase) ||
+               fileName.Equals("netstandard.dll", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/twodog.xunit/GodotFixture.cs
+++ b/twodog.xunit/GodotFixture.cs
@@ -21,6 +21,11 @@ public class GodotFixture : IDisposable
         var assemblyDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
         var projectPath = Engine.ResolveProjectDir();
 
+        // Pre-load game assemblies into Default context BEFORE starting Godot.
+        // This prevents type identity issues where Godot loads assemblies into
+        // PluginLoadContext while test code expects them in Default context.
+        AssemblyPreloader.PreloadGameAssemblies(projectPath);
+
         // Set GODOTSHARP_DIR so Godot finds GodotPlugins.dll in the output directory.
         // On Linux/.NET 8+, must use native setenv() because .NET's SetEnvironmentVariable
         // doesn't propagate to native getenv(). On Windows, the .NET API works fine.

--- a/twodog.xunit/GodotHeadlessFixture.cs
+++ b/twodog.xunit/GodotHeadlessFixture.cs
@@ -23,6 +23,11 @@ public class GodotHeadlessFixture : IDisposable
         var assemblyDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
         var projectPath = Engine.ResolveProjectDir();
 
+        // Pre-load game assemblies into Default context BEFORE starting Godot.
+        // This prevents type identity issues where Godot loads assemblies into
+        // PluginLoadContext while test code expects them in Default context.
+        AssemblyPreloader.PreloadGameAssemblies(projectPath);
+
         // Set GODOTSHARP_DIR so Godot finds GodotPlugins.dll in the output directory.
         // When running via dotnet test, the host process is /usr/share/dotnet/dotnet,
         // so Godot's exe_dir fallback resolves to the wrong directory.


### PR DESCRIPTION
Contains fixes for the problem where referenced assemblies in tests are double-loaded (by Godot) or are loaded again but with a somewhat different context.

Fixes #17 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version to 0.1.16-pre

* **Bug Fixes**
  * Enhanced assembly loading in test fixtures to prevent type identity conflicts across different assembly contexts
  * Game assemblies are now preloaded prior to Godot initialization in both standard and headless test fixtures, ensuring consistent behavior during test startup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->