### PR TITLE
ci: update actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/build-natives.yml
+++ b/.github/workflows/build-natives.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Compute submodule hash
         id: hash
@@ -66,7 +66,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -99,7 +99,7 @@ jobs:
             libwayland-dev
 
       - name: Cache SCons
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             godot/.scons_cache
@@ -117,28 +117,28 @@ jobs:
             --cache-path godot/.scons_cache
 
       - name: Upload GodotSharp assemblies
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: godotsharp
           path: godot/bin/GodotSharp/
           retention-days: 7
 
       - name: Upload GodotSharp NuGet packages
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: godotsharp-nupkgs
           path: godot/bin/GodotSharp/Tools/nupkgs/
           retention-days: 7
 
       - name: Upload source generators
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: godot-source-generators
           path: godot/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/bin/Release/netstandard2.0/Godot.SourceGenerators.dll
           retention-days: 7
 
       - name: Upload Linux editor binary
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: godot-editor-linux-x64
           path: godot/bin/godot.linuxbsd.editor.x86_64.executable.mono
@@ -220,7 +220,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -274,7 +274,7 @@ jobs:
 
       # Cache SCons build
       - name: Cache SCons
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             godot/.scons_cache
@@ -316,7 +316,7 @@ jobs:
 
       # Upload artifact
       - name: Upload artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact_name }}
           path: dist/${{ matrix.artifact_name }}.zip
@@ -331,7 +331,7 @@ jobs:
 
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       hash: ${{ steps.check.outputs.hash }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Check native library availability
         id: check
@@ -69,7 +69,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -176,7 +176,7 @@ jobs:
         run: ls -lh packages/
 
       - name: Upload godot-bin artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: godot-bin
           path: |
@@ -185,7 +185,7 @@ jobs:
           retention-days: 3
 
       - name: Upload NuGet packages
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: nuget-packages
           path: packages/
@@ -200,7 +200,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -208,7 +208,7 @@ jobs:
           dotnet-version: '8.0.x'
 
       - name: Download godot-bin artifact
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: godot-bin
           path: godot
@@ -219,7 +219,7 @@ jobs:
           python3 import-project.py ./game
 
       - name: Upload imported game data
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: game-imported
           path: game/.godot/
@@ -246,7 +246,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -254,19 +254,19 @@ jobs:
           dotnet-version: '8.0.x'
 
       - name: Download godot-bin artifact
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: godot-bin
           path: godot
 
       - name: Download imported game data
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: game-imported
           path: game/.godot
 
       - name: Download NuGet packages
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: nuget-packages
           path: packages
@@ -292,7 +292,7 @@ jobs:
 
     steps:
       - name: Download NuGet packages
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: nuget-packages
           path: packages


### PR DESCRIPTION
Bumps all GitHub Actions to their latest majors (Node 24 runtimes), resolving the Node.js 20 deprecation warnings. See commit message for the per-action breaking-change review — none affect our usage. setup-dotnet and setup-python were already current.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/outfox/codesmith/2dog/pr/26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786400562&installation_id=140518117&pr_number=26&repository=outfox%2F2dog&return_to=https%3A%2F%2Fgithub.com%2Foutfox%2F2dog%2Fpull%2F26&signature=12a6c749cc52b279bfc66b3cd39590127489d913c2016648fe7944261610f715"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->