### PR TITLE
fix: serialize engine boots and make project resolution CWD-independent

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
              skip-duplicate push would otherwise keep the old package);
              reset to 0 when GodotVersion changes. NuGet normalizes a trailing .0
              (4.7.0.0 publishes as 4.7.0). -->
-        <NativesRevision>28</NativesRevision>
+        <NativesRevision>29</NativesRevision>
         <TwoDogVersion>$(GodotVersion).$(TwoDogRevision)</TwoDogVersion>
         <NativesVersion>$(GodotVersion).$(NativesRevision)</NativesVersion>
         <!-- Emscripten version for browser-wasm natives. Must match the emscripten

--- a/twodog.engine/Engine.cs
+++ b/twodog.engine/Engine.cs
@@ -108,6 +108,13 @@ public class Engine(string project, string? path = null, params string[] args) :
     /// </summary>
     public string? ProjectAssemblyDir { get; init; }
 
+    /// <summary>
+    /// How long Start() waits for the process-wide boot lock that serializes
+    /// engine boots (they mutate the process CWD and environment). Only ever
+    /// exceeded when another boot in this process is stuck.
+    /// </summary>
+    public TimeSpan BootLockTimeout { get; init; } = TimeSpan.FromSeconds(120);
+
     /// <summary>Full path of the libgodot this load context actually loaded, when known.</summary>
     public static string? LoadedNativePath => LibGodotLoader.LoadedLibraryPath;
 
@@ -125,27 +132,44 @@ public class Engine(string project, string? path = null, params string[] args) :
 
     public GodotInstance Start()
     {
-        if (_godotInstancePtr != IntPtr.Zero)
-            throw new InvalidOperationException(
-                $"{nameof(Engine)}: A Godot instance is already running. Only one instance may exist at a time " +
-                "(a Godot limitation) - dispose the previous Engine before starting a new one.");
+        ThrowIfInstanceRunning();
 
         if (OperatingSystem.IsBrowser())
         {
             // No filesystem hosting on web: the game's plugins initializer
             // function pointer must have been registered up front (there is
-            // no GodotPlugins.dll to load).
+            // no GodotPlugins.dll to load). One statically linked instance per
+            // page - nothing to serialize, and wasm has no named mutexes.
             if (!WebHost.HasPluginsInitializer)
                 throw new InvalidOperationException(
                     $"{nameof(Engine)}: On browser, call {nameof(RegisterWebPluginsInitializer)}() with " +
                     "the game assembly's plugins-initializer pointer (see TwoDogWebBoot.cs in the " +
                     "2dog template; requires the LIBGODOT_ENABLED define) before Start().");
-        }
-        else
-        {
-            ConfigureGodotSharpDir(ProjectAssemblyDir);
+            return StartCore();
         }
 
+        // Boot mutates process-global state: the environment variables written
+        // below are read during instance creation, and Godot's --path handling
+        // moves the process CWD. Engines in other load contexts run their own
+        // copy of this class, so the serialization must be OS-level.
+        using (ProcessBootLock.Acquire(BootLockTimeout))
+        {
+            ThrowIfInstanceRunning();
+            ConfigureGodotSharpDir(ProjectAssemblyDir);
+            return StartCore();
+        }
+    }
+
+    private void ThrowIfInstanceRunning()
+    {
+        if (_godotInstancePtr != IntPtr.Zero)
+            throw new InvalidOperationException(
+                $"{nameof(Engine)}: A Godot instance is already running. Only one instance may exist at a time " +
+                "(a Godot limitation) - dispose the previous Engine before starting a new one.");
+    }
+
+    private GodotInstance StartCore()
+    {
         if (NativePath is { } nativePath)
         {
             if (OperatingSystem.IsBrowser())
@@ -157,12 +181,14 @@ public class Engine(string project, string? path = null, params string[] args) :
 
         Console.WriteLine("Starting Godot instance...");
 
-        // Prepare arguments for Godot
+        // Prepare arguments for Godot. The project path goes out absolute:
+        // relative paths would resolve against the process CWD, which another
+        // engine's boot may have moved.
         List<string> godotArgs = [project];
         if (!string.IsNullOrEmpty(path))
         {
             godotArgs.Add("--path");
-            godotArgs.Add(path);
+            godotArgs.Add(Path.GetFullPath(path));
         }
 
         godotArgs.AddRange(args);

--- a/twodog.engine/Engine.cs
+++ b/twodog.engine/Engine.cs
@@ -109,11 +109,27 @@ public class Engine(string project, string? path = null, params string[] args) :
     public string? ProjectAssemblyDir { get; init; }
 
     /// <summary>
+    /// Absolute project path, captured at construction: boot-time CWD churn
+    /// (another instance's boot or DirAccess moving the process CWD) must not
+    /// change which project a relative path resolves to.
+    /// </summary>
+    private readonly string? _projectPath =
+        string.IsNullOrEmpty(path) ? null : Path.GetFullPath(path);
+
+    /// <summary>
     /// How long Start() waits for the process-wide boot lock that serializes
-    /// engine boots (they mutate the process CWD and environment). Only ever
-    /// exceeded when another boot in this process is stuck.
+    /// engine boots (they mutate the process CWD and environment). Matches the
+    /// hosting layer's boot-gate timeout: generous enough for a debug-native
+    /// first boot on a loaded CI runner, so it is only ever exceeded when
+    /// another boot in this process is genuinely stuck.
     /// </summary>
     public TimeSpan BootLockTimeout { get; init; } = TimeSpan.FromSeconds(120);
+
+    /// <summary>
+    /// Name of the process-wide named mutex that serializes engine boots.
+    /// Public so hosts and tests can observe or contend on it deliberately.
+    /// </summary>
+    public static string BootLockName => ProcessBootLock.Name;
 
     /// <summary>Full path of the libgodot this load context actually loaded, when known.</summary>
     public static string? LoadedNativePath => LibGodotLoader.LoadedLibraryPath;
@@ -181,14 +197,13 @@ public class Engine(string project, string? path = null, params string[] args) :
 
         Console.WriteLine("Starting Godot instance...");
 
-        // Prepare arguments for Godot. The project path goes out absolute:
-        // relative paths would resolve against the process CWD, which another
-        // engine's boot may have moved.
+        // Prepare arguments for Godot. The project path was made absolute at
+        // construction, so CWD movement between then and now cannot redirect it.
         List<string> godotArgs = [project];
-        if (!string.IsNullOrEmpty(path))
+        if (_projectPath is { } projectPath)
         {
             godotArgs.Add("--path");
-            godotArgs.Add(Path.GetFullPath(path));
+            godotArgs.Add(projectPath);
         }
 
         godotArgs.AddRange(args);

--- a/twodog.engine/ProcessBootLock.cs
+++ b/twodog.engine/ProcessBootLock.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Threading;
+
+namespace twodog;
+
+/// <summary>
+/// Serializes engine boots across the whole process. Boot mutates process-global
+/// state (the CWD via Godot's --path chdir, the GODOT_PROJECT_ASSEMBLY_DIR /
+/// GODOTSHARP_DIR environment variables read during instance creation), and
+/// multi-instance hosts run each engine in an isolated AssemblyLoadContext with
+/// its own copy of this assembly - a plain static lock would be per-context.
+/// A named local mutex has OS-level identity, so every copy contends on the
+/// same lock; the process id keeps unrelated processes unserialized.
+/// </summary>
+internal static class ProcessBootLock
+{
+    /// <summary>Stable, documented name: tests contend on it deliberately.</summary>
+    internal static string Name => $@"Local\2dog-engine-boot-{Environment.ProcessId}";
+
+    /// <summary>
+    /// Acquires the process-wide boot lock, or throws <see cref="TimeoutException"/>
+    /// (message contains "boot lock") without touching any engine state.
+    /// </summary>
+    internal static IDisposable Acquire(TimeSpan timeout)
+    {
+        var mutex = new Mutex(initiallyOwned: false, Name);
+        try
+        {
+            bool acquired;
+            try
+            {
+                acquired = mutex.WaitOne(timeout);
+            }
+            catch (AbandonedMutexException)
+            {
+                // A previous boot's thread died while holding the lock. The lock is
+                // ours now, and the next boot rewrites the global state it guards.
+                acquired = true;
+            }
+
+            if (!acquired)
+                throw new TimeoutException(
+                    $"{nameof(Engine)}: timed out after {timeout} waiting for the process-wide boot lock - " +
+                    $"another engine boot in this process is stuck (see {nameof(Engine)}.{nameof(Engine.BootLockTimeout)}).");
+        }
+        catch
+        {
+            mutex.Dispose();
+            throw;
+        }
+
+        return new Holder(mutex);
+    }
+
+    private sealed class Holder(Mutex mutex) : IDisposable
+    {
+        public void Dispose()
+        {
+            mutex.ReleaseMutex();
+            mutex.Dispose();
+        }
+    }
+}

--- a/twodog.engine/ProcessBootLock.cs
+++ b/twodog.engine/ProcessBootLock.cs
@@ -20,6 +20,8 @@ internal static class ProcessBootLock
     /// <summary>
     /// Acquires the process-wide boot lock, or throws <see cref="TimeoutException"/>
     /// (message contains "boot lock") without touching any engine state.
+    /// The returned holder must be disposed on the acquiring thread: mutex
+    /// ownership is thread-affine and ReleaseMutex throws elsewhere.
     /// </summary>
     internal static IDisposable Acquire(TimeSpan timeout)
     {

--- a/twodog.tests/Engine/BootCwdIndependenceTests.cs
+++ b/twodog.tests/Engine/BootCwdIndependenceTests.cs
@@ -20,6 +20,15 @@ public class BootCwdIndependenceTests
     [Fact]
     public void BootedProjectMatchesRequestedPath_WhileCwdChurns()
     {
+        // Windows documents the process CWD as not thread-safe: concurrent
+        // SetCurrentDirectory while native code runs can fault inside OS path
+        // machinery (crashed win-x64 Release CI with an access violation).
+        // The churn scenario runs on Unix, where chdir/getcwd are atomic
+        // syscalls; the realistic Windows adversary - another engine's boot
+        // moving the CWD - is serialized away by the boot lock (BootLockTests).
+        Assert.SkipWhen(OperatingSystem.IsWindows(),
+            "concurrent SetCurrentDirectory is not thread-safe on Windows");
+
         var projectDir = Engine.ResolveProjectDir();
         AssemblyPreloader.PreloadGameAssemblies(projectDir);
 

--- a/twodog.tests/Engine/BootCwdIndependenceTests.cs
+++ b/twodog.tests/Engine/BootCwdIndependenceTests.cs
@@ -1,0 +1,60 @@
+using twodog;
+using twodog.fixture;
+using twodog.Hosting.Xunit;
+using Godot;
+using Environment = System.Environment;
+
+namespace twodog.tests.EngineTests;
+
+// Boots must resolve the requested project even while the process CWD moves
+// under them: another engine instance booting (or a DirAccess call in any
+// instance) chdirs the whole process. Regression test for the CI flake where
+// the classic engine booted against a hosting fixture's scratch project.
+// No fixture on purpose: the collection manages its own engines.
+[CollectionDefinition(nameof(BootCwdIndependenceCollection), DisableParallelization = true)]
+public class BootCwdIndependenceCollection;
+
+[Collection(nameof(BootCwdIndependenceCollection))]
+public class BootCwdIndependenceTests
+{
+    [Fact]
+    public void BootedProjectMatchesRequestedPath_WhileCwdChurns()
+    {
+        var projectDir = Engine.ResolveProjectDir();
+        AssemblyPreloader.PreloadGameAssemblies(projectDir);
+
+        // A bootable decoy project in temp: if a boot picks up the CWD instead
+        // of the requested path, it finds this project's name, not "showcase".
+        var decoy = ScratchProject.Create("cwd-decoy");
+        var originalCwd = Environment.CurrentDirectory;
+        var stop = false;
+        var churn = new Thread(() =>
+        {
+            var temp = Path.GetTempPath();
+            while (!Volatile.Read(ref stop))
+            {
+                Environment.CurrentDirectory = decoy;
+                Environment.CurrentDirectory = temp;
+            }
+        }) { IsBackground = true };
+
+        churn.Start();
+        try
+        {
+            for (var i = 0; i < 3; i++)
+            {
+                using var engine = new Engine($"cwd-independence-{i}", projectDir, "--headless");
+                using var godot = engine.Start();
+                var name = (string)ProjectSettings.GetSetting("application/config/name");
+                Assert.Equal("showcase", name);
+            }
+        }
+        finally
+        {
+            Volatile.Write(ref stop, true);
+            churn.Join();
+            Environment.CurrentDirectory = originalCwd;
+            ScratchProject.Delete(decoy);
+        }
+    }
+}

--- a/twodog.tests/Engine/BootCwdIndependenceTests.cs
+++ b/twodog.tests/Engine/BootCwdIndependenceTests.cs
@@ -35,6 +35,9 @@ public class BootCwdIndependenceTests
             {
                 Environment.CurrentDirectory = decoy;
                 Environment.CurrentDirectory = temp;
+                // Stay adversarial without starving the booting thread on
+                // small CI runners.
+                Thread.Yield();
             }
         }) { IsBackground = true };
 

--- a/twodog.tests/Engine/BootLockTests.cs
+++ b/twodog.tests/Engine/BootLockTests.cs
@@ -1,0 +1,55 @@
+using twodog;
+
+namespace twodog.tests.EngineTests;
+
+// Contends on the process-wide boot lock, so nothing else may boot while these
+// tests run. No fixture on purpose; like all Godot collections it disables
+// parallelization.
+[CollectionDefinition(nameof(BootLockCollection), DisableParallelization = true)]
+public class BootLockCollection;
+
+[Collection(nameof(BootLockCollection))]
+public class BootLockTests
+{
+    [Fact]
+    public void Start_TimesOutFailClosed_WhileAnotherBootHoldsTheLock()
+    {
+        // The lock's name is a documented contract: one named local mutex per
+        // process, shared by every load context's copy of the engine assembly.
+        // A mutex is reentrant on its owning thread, so the contending holder
+        // must be a different thread - like a real concurrent boot.
+        using var held = new ManualResetEventSlim();
+        using var release = new ManualResetEventSlim();
+        var holder = new Thread(() =>
+        {
+            using var mutex = new Mutex(initiallyOwned: false, $@"Local\2dog-engine-boot-{Environment.ProcessId}");
+            mutex.WaitOne();
+            held.Set();
+            release.Wait();
+            mutex.ReleaseMutex();
+        }) { IsBackground = true };
+        holder.Start();
+        held.Wait();
+
+        try
+        {
+            // The bogus project path is never touched: the lock times out
+            // before any environment write or native call happens.
+            using var engine = new Engine(
+                "bootlock-timeout",
+                Path.Combine(Path.GetTempPath(), "2dog-no-such-project"),
+                "--headless")
+            {
+                BootLockTimeout = TimeSpan.FromMilliseconds(250),
+            };
+
+            var ex = Assert.Throws<TimeoutException>(() => engine.Start());
+            Assert.Contains("boot lock", ex.Message);
+        }
+        finally
+        {
+            release.Set();
+            holder.Join();
+        }
+    }
+}

--- a/twodog.tests/Engine/BootLockTests.cs
+++ b/twodog.tests/Engine/BootLockTests.cs
@@ -29,7 +29,7 @@ public class BootLockTests
             mutex.ReleaseMutex();
         }) { IsBackground = true };
         holder.Start();
-        held.Wait();
+        held.Wait(TestContext.Current.CancellationToken);
 
         try
         {

--- a/twodog.tests/Engine/BootLockTests.cs
+++ b/twodog.tests/Engine/BootLockTests.cs
@@ -14,15 +14,15 @@ public class BootLockTests
     [Fact]
     public void Start_TimesOutFailClosed_WhileAnotherBootHoldsTheLock()
     {
-        // The lock's name is a documented contract: one named local mutex per
-        // process, shared by every load context's copy of the engine assembly.
-        // A mutex is reentrant on its owning thread, so the contending holder
-        // must be a different thread - like a real concurrent boot.
+        // One named local mutex per process, shared by every load context's
+        // copy of the engine assembly. A mutex is reentrant on its owning
+        // thread, so the contending holder must be a different thread - like
+        // a real concurrent boot.
         using var held = new ManualResetEventSlim();
         using var release = new ManualResetEventSlim();
         var holder = new Thread(() =>
         {
-            using var mutex = new Mutex(initiallyOwned: false, $@"Local\2dog-engine-boot-{Environment.ProcessId}");
+            using var mutex = new Mutex(initiallyOwned: false, Engine.BootLockName);
             mutex.WaitOne();
             held.Set();
             release.Wait();


### PR DESCRIPTION
Fixes the `Test (win-x64)` flake (v4.7.1.56 tag run): parallel engine boots in one process raced on the process CWD and boot env vars, so an engine could boot against the wrong project.

- `ProcessBootLock`: named local mutex serializes every `Engine.Start` across all AssemblyLoadContexts; `--path` now passed absolute; `BootLockTimeout` fails closed.
- godot fork (submodule bump, NativesRevision 29): `--path` records `project_path` explicitly and `ProjectSettings::_setup` resolves absolute paths without consulting the CWD.
- New tests: `BootLockTests` (lock timeout contract), `BootCwdIndependenceTests` (boot survives CWD churn).