### PR TITLE
fix: never delete .symbols from the web bundle

### DIFF
--- a/docs/content/hosts/web.md
+++ b/docs/content/hosts/web.md
@@ -101,7 +101,7 @@ The host also contains:
 | `TwoDogWebExportPreset` | `Web` | Export preset in `export_presets.cfg` |
 | `TwoDogWebPackName` | `godot.pck` | Deployed pack name |
 | `TwoDogWebSizeManifest` | `true` | Write `twodog.sizes.json` for the shell's progress bar |
-| `TwoDogWebStripMaps` | `true` for release | Delete `*.js.map` / `*.symbols` from the bundle |
+| `TwoDogWebStripMaps` | `true` for release | Delete `*.js.map` sourcemaps from the bundle |
 | `TwoDogWebPrecompress` | `true` | Write `.br`/`.gz` siblings next to payload files |
 
 Loading-performance knobs (`WasmInitialHeapSize`, `WasmEmitSymbolMap`,

--- a/docs/content/web.md
+++ b/docs/content/web.md
@@ -95,7 +95,7 @@ All web host properties are optional:
 | `TwoDogWebExportPreset` | `Web` | Export preset name in `export_presets.cfg` |
 | `TwoDogWebPackName` | `godot.pck` | Deployed pack file name |
 | `TwoDogWebSizeManifest` | `true` | Write `twodog.sizes.json` (exact wasm/pck byte sizes); the boot shell reads it to render a determinate progress bar |
-| `TwoDogWebStripMaps` | `true` for release | Delete `*.js.map` and `*.symbols` from the bundle |
+| `TwoDogWebStripMaps` | `true` for release | Delete `*.js.map` sourcemaps from the bundle |
 | `TwoDogWebPrecompress` | `true` | Write `.br`/`.gz` siblings next to every sizeable bundle file |
 | `TwoDogWebPrecompressLevel` | `Optimal` | `CompressionLevel` for the siblings; `SmallestSize` compresses harder at higher publish cost |
 | `WasmEmitSymbolMap` | `false` | `true` restores `dotnet.native.js.symbols` (~20 MB, downloaded at every boot) for symbolicated native stack traces |

--- a/platforms/twodog.browser-wasm/README.md
+++ b/platforms/twodog.browser-wasm/README.md
@@ -45,7 +45,7 @@ single-threaded engine build requires no COOP/COEP headers.
 | `TwoDogWebExportPreset` | `Web` | Export preset name in `export_presets.cfg` |
 | `TwoDogWebPackName` | `godot.pck` | Deployed pack file name |
 | `TwoDogWebSizeManifest` | `true` | Write `twodog.sizes.json` (exact wasm/pck sizes) for the boot shell's progress bar |
-| `TwoDogWebStripMaps` | `true` for release | Delete `*.js.map` / `*.symbols` from the bundle |
+| `TwoDogWebStripMaps` | `true` for release | Delete `*.js.map` sourcemaps from the bundle |
 | `TwoDogWebPrecompress` | `true` | Write `.br`/`.gz` siblings next to payload files for servers with precompressed-static support |
 | `TwoDogWebPrecompressLevel` | `Optimal` | `CompressionLevel` for the siblings (`SmallestSize` for final deploys) |
 | `WasmEmitSymbolMap` | `false` | `true` restores `dotnet.native.js.symbols` (downloaded at boot; symbolicates native stack traces) |

--- a/platforms/twodog.browser-wasm/build/2dog.browser-wasm.targets
+++ b/platforms/twodog.browser-wasm/build/2dog.browser-wasm.targets
@@ -28,7 +28,7 @@
         TwoDogWebPackName:      deployed pck file name (default 'godot.pck')
         TwoDogWebSizeManifest:  'false' skips twodog.sizes.json (exact wasm/pck
                                 sizes the boot shell's progress bar reads)
-        TwoDogWebStripMaps:     'false' keeps *.js.map / *.symbols in release
+        TwoDogWebStripMaps:     'false' keeps *.js.map sourcemaps in release
                                 bundles
         TwoDogWebPrecompress:   'false' skips the .br/.gz sibling files
                                 (servers with precompressed-static support and
@@ -191,12 +191,13 @@
               Condition="Exists('$(WasmAppDir)/_framework/dotnet.native.wasm')"/>
         <Delete Files="$(WasmAppDir)/_framework/libgodot.wasm"/>
 
-        <!-- Debug-only artifacts: sourcemaps are fetched with devtools open,
-             *.symbols at every boot (belt-and-braces - WasmEmitSymbolMap
-             already defaults off). -->
+        <!-- Sourcemaps are only fetched with devtools open; safe to strip.
+             *.symbols must NOT be deleted here: dotnet.boot.js is a manifest
+             and mono_download_assets fails the whole boot on any listed asset
+             that 404s. Whether symbols exist is WasmEmitSymbolMap's job - it
+             keeps both the file and its manifest entry out on a fresh relink. -->
         <ItemGroup Condition="'$(TwoDogWebStripMaps)' == 'true'">
             <_TwoDogWebDebugArtifacts Include="$(WasmAppDir)/_framework/*.js.map"/>
-            <_TwoDogWebDebugArtifacts Include="$(WasmAppDir)/_framework/*.symbols"/>
         </ItemGroup>
         <Delete Files="@(_TwoDogWebDebugArtifacts)" Condition="'$(TwoDogWebStripMaps)' == 'true'"/>
 


### PR DESCRIPTION
dotnet.boot.js is a manifest: mono_download_assets downloads every listed asset at boot and fails hard on a 404. The TwoDogWebStripMaps delete removed dotnet.native.js.symbols without touching the manifest, breaking any publish whose manifest still listed it (stale incremental obj/ from a pre-change build, or WasmEmitSymbolMap=true).