### PR TITLE
Unify engine lifetime and harden quit/restart

### DIFF
--- a/.github/scripts/blazor-lifetime.test.mjs
+++ b/.github/scripts/blazor-lifetime.test.mjs
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const source = await readFile(new URL('../../twodog.blazor/wwwroot/2dog.blazor.js', import.meta.url), 'utf8');
+let generation = 0;
+const deferred = () => {
+    let resolve;
+    const promise = new Promise((r) => { resolve = r; });
+    return { promise, resolve };
+};
+
+async function view(initFS = async () => {}) {
+    const calls = [];
+    globalThis.document = { baseURI: 'https://example.test/' };
+    globalThis.window = { devicePixelRatio: 1 };
+    globalThis.ResizeObserver = class {
+        observe() { calls.push('observe'); }
+        disconnect() { calls.push('disconnect'); }
+    };
+    globalThis.Blazor = { runtime: { Module: {
+        initFS,
+        copyToFS: () => calls.push('copy'),
+        initConfig: () => calls.push('configure'),
+    } } };
+    const module = await import(`data:text/javascript,${encodeURIComponent(source)}#${generation++}`);
+    const canvas = { tabIndex: -1, clientWidth: 640, clientHeight: 480 };
+    const options = { packUrl: 'godot.pck', packName: 'godot.pck', resize: 0, locale: 'en' };
+    return { ...module, canvas, options, calls };
+}
+
+test('release during filesystem initialization prevents late fetch and canvas setup', async () => {
+    const fs = deferred();
+    const v = await view(() => fs.promise);
+    globalThis.fetch = async () => { throw new Error('A cancelled view must not fetch'); };
+    const starting = v.prepare(v.canvas, v.options);
+    v.release(v.canvas);
+    fs.resolve();
+    await assert.rejects(starting, { name: 'AbortError' });
+    assert.deepEqual(v.calls, []);
+});
+
+test('release while reading the pack prevents overwriting the next view runtime', async () => {
+    const body = deferred();
+    const reading = deferred();
+    const v = await view();
+    globalThis.fetch = async () => ({ ok: true, arrayBuffer() { reading.resolve(); return body.promise; } });
+    const starting = v.prepare(v.canvas, v.options);
+    await reading.promise;
+    v.release(v.canvas);
+    body.resolve(new ArrayBuffer(0));
+    await assert.rejects(starting, { name: 'AbortError' });
+    assert.deepEqual(v.calls, []);
+});
+
+test('successful lifetimes release their observers and configure a fresh canvas', async () => {
+    const v = await view();
+    globalThis.fetch = async () => ({ ok: true, arrayBuffer: async () => new ArrayBuffer(0) });
+    await v.prepare(v.canvas, v.options);
+    v.release(v.canvas);
+    v.release(v.canvas);
+    const nextCanvas = { tabIndex: -1, clientWidth: 800, clientHeight: 600 };
+    await v.prepare(nextCanvas, v.options);
+    v.release(nextCanvas);
+    assert.deepEqual(v.calls, ['copy', 'observe', 'configure', 'disconnect', 'copy', 'observe', 'configure', 'disconnect']);
+    assert.equal(nextCanvas.width, 800);
+    assert.equal(nextCanvas.height, 600);
+});
+
+test('a replacement view joins filesystem initialization left behind by a cancelled view', async () => {
+    const fs = deferred();
+    let mounts = 0;
+    const v = await view(() => { mounts++; return fs.promise; });
+    globalThis.fetch = async () => ({ ok: true, arrayBuffer: async () => new ArrayBuffer(0) });
+    const first = v.prepare(v.canvas, v.options);
+    const cancelled = assert.rejects(first, { name: 'AbortError' });
+    v.release(v.canvas);
+    const nextCanvas = { tabIndex: -1, clientWidth: 800, clientHeight: 600 };
+    const next = v.prepare(nextCanvas, v.options);
+    fs.resolve();
+    await Promise.all([cancelled, next]);
+    assert.equal(mounts, 1);
+    assert.deepEqual(v.calls, ['copy', 'observe', 'configure']);
+    v.release(nextCanvas);
+});

--- a/.github/scripts/blazor-lifetime.test.mjs
+++ b/.github/scripts/blazor-lifetime.test.mjs
@@ -1,6 +1,18 @@
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
-import test from 'node:test';
+import test, { beforeEach, afterEach } from 'node:test';
+
+const globalNames = ['document', 'window', 'ResizeObserver', 'Blazor', 'fetch'];
+let savedGlobals;
+beforeEach(() => {
+    savedGlobals = new Map(globalNames.map((name) => [name, Object.getOwnPropertyDescriptor(globalThis, name)]));
+});
+afterEach(() => {
+    for (const [name, descriptor] of savedGlobals) {
+        if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+        else delete globalThis[name];
+    }
+});
 
 const source = await readFile(new URL('../../twodog.blazor/wwwroot/2dog.blazor.js', import.meta.url), 'utf8');
 let generation = 0;

--- a/.github/scripts/browser-restart-smoke.mjs
+++ b/.github/scripts/browser-restart-smoke.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
-// Drives the Blazor showcase through a second engine lifetime: waits for the first smoke pass, clicks
-// "Quit engine", waits for the quit to complete, clicks "Start engine", then waits for the smoke marker of
-// lifetime 2. Usage: browser-restart-smoke.mjs <url> [timeout-ms] [debug-port]
+// Drives the Blazor showcase through quit/start and restart-from-exit-callback lifetimes.
+// Fails on browser/runtime errors as well as a failed or missing smoke marker.
+// Usage: browser-restart-smoke.mjs <url> [timeout-ms] [debug-port]
 
 const [targetUrl, timeoutValue = "120000", portValue = "9222"] = process.argv.slice(2);
 if (!targetUrl) {
@@ -11,6 +11,11 @@ if (!targetUrl) {
 const timeoutMs = Number.parseInt(timeoutValue, 10);
 const debugPort = Number.parseInt(portValue, 10);
 const deadline = Date.now() + timeoutMs;
+// Bound stalled DevTools calls too: a hung wasm frame may never answer Runtime.evaluate.
+setTimeout(() => {
+    console.error('Engine restart smoke timed out');
+    process.exit(1);
+}, timeoutMs).unref();
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const targets = await (await fetch(`http://127.0.0.1:${debugPort}/json/list`)).json();
@@ -23,6 +28,7 @@ if (!page?.webSocketDebuggerUrl) {
 const ws = new WebSocket(page.webSocketDebuggerUrl);
 await new Promise((resolve, reject) => { ws.addEventListener("open", resolve); ws.addEventListener("error", reject); });
 let nextId = 0;
+let browserFailure = null;
 const pending = new Map();
 ws.addEventListener("message", (message) => {
     const data = JSON.parse(message.data);
@@ -31,9 +37,12 @@ ws.addEventListener("message", (message) => {
         pending.delete(data.id);
     } else if (data.method === "Runtime.consoleAPICalled") {
         const text = data.params.args.map((a) => a.value ?? a.description ?? "").join(" ");
+        if (data.params.type === "error" || /(^|\n)ERROR:/.test(text)) browserFailure ??= text;
         if (/error|exception|2DOG|Engine:|destroyed/i.test(text)) console.log(`[browser:${data.params.type}] ${text.slice(0, 300)}`);
     } else if (data.method === "Runtime.exceptionThrown") {
-        console.error(`[browser:exception] ${data.params.exceptionDetails.exception?.description ?? data.params.exceptionDetails.text}`);
+        const text = data.params.exceptionDetails.exception?.description ?? data.params.exceptionDetails.text;
+        browserFailure ??= text;
+        console.error(`[browser:exception] ${text}`);
     }
 });
 const send = (method, params = {}) => new Promise((resolve) => {
@@ -72,6 +81,10 @@ const waitFor = async (what, predicate) => {
     let last = null;
     while (Date.now() < deadline) {
         last = await state();
+        if (browserFailure) throw new Error(`Browser runtime error: ${browserFailure}`);
+        if (last.smoke === 'failed' || last.status?.startsWith('Failed:')) {
+            throw new Error(`Browser reported failure: ${JSON.stringify(last)}`);
+        }
         if (predicate(last)) {
             console.log(`${what}: ${JSON.stringify(last)}`);
             return last;
@@ -97,6 +110,11 @@ try {
     await waitFor("second lifetime", (s) => running(s) && s.lifetime === "2" && s.status === "Running");
     await sleep(1000);
     await waitFor("second lifetime settled", (s) => running(s) && s.lifetime === "2" && s.status === "Running");
+    const restart = await click("Restart engine");
+    if (restart !== "clicked") throw new Error(`Restart engine button: ${restart}`);
+    await waitFor("callback restart", (s) => running(s) && s.lifetime === "3" && s.status === "Running");
+    await sleep(1000);
+    await waitFor("callback restart settled", (s) => running(s) && s.lifetime === "3" && s.status === "Running");
     console.log("Engine restart smoke passed");
     ws.close();
     process.exit(0);

--- a/.github/scripts/test-with-watchdog.sh
+++ b/.github/scripts/test-with-watchdog.sh
@@ -3,6 +3,7 @@
 # actually run tests. vstest's --blame-hang only dumps its own testhost, but xunit v3 executes the
 # assembly in a child process and HelperToolTestBed spawns 2dog.import grandchildren; on a hang
 # those are the stacks that matter, so we createdump each of them before killing the tree.
+# On macOS, createdump can itself hang; retain test output and a process snapshot instead.
 # Usage: test-with-watchdog.sh <Configuration> [timeout-seconds]
 set -euo pipefail
 
@@ -34,19 +35,28 @@ if [[ "${RUNNER_OS:-}" == "Linux" ]]; then
   sudo sysctl -q -w kernel.yama.ptrace_scope=0 || true
 fi
 
-dotnet test 2dog.tests.slnf -c "$config" --no-restore \
-  --blame-crash --blame-crash-dump-type full &
+if [[ "${RUNNER_OS:-}" == "macOS" ]]; then
+  dotnet test 2dog.tests.slnf -c "$config" --no-restore \
+    --blame --logger 'console;verbosity=normal' &
+else
+  dotnet test 2dog.tests.slnf -c "$config" --no-restore \
+    --blame-crash --blame-crash-dump-type full &
+fi
 test_pid=$!
 
 elapsed=0
 while kill -0 "$test_pid" 2>/dev/null; do
   if (( elapsed >= limit )); then
-    echo "::error::Test run ($config) exceeded ${limit}s; dumping test processes to $dumps"
+    echo "::error::Test run ($config) exceeded ${limit}s; collecting diagnostics in $dumps"
     mkdir -p "$dumps"
-    for pid in $(pgrep -f "$pattern" || true); do
-      echo "--- pid $pid: $(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null || ps -o command= -p "$pid")"
-      "$createdump" --full -f "$dumps/hang_${pid}.dmp" "$pid" || echo "createdump failed for $pid"
-    done
+    if [[ "${RUNNER_OS:-}" == "macOS" ]]; then
+      ps -axo pid,ppid,state,etime,command > "$dumps/processes.txt" || true
+    else
+      for pid in $(pgrep -f "$pattern" || true); do
+        echo "--- pid $pid: $(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null || ps -o command= -p "$pid")"
+        "$createdump" --full -f "$dumps/hang_${pid}.dmp" "$pid" || echo "createdump failed for $pid"
+      done
+    fi
     pkill -TERM -P "$test_pid" || true
     kill -TERM "$test_pid" || true
     sleep 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -749,6 +749,9 @@ jobs:
       # Same probe through the Blazor host: the published ASP.NET Core server
       # serves the client, whose home page runs GodotApiSmoke after GodotView
       # started the engine and marks the DOM.
+      - name: Test Blazor preparation cancellation
+        run: node --test .github/scripts/blazor-lifetime.test.mjs
+
       - name: Run Blazor browser smoke
         run: |
           CHROME=$(command -v google-chrome || command -v chromium || command -v chromium-browser || true)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
         <TwoDogRevision>81</TwoDogRevision>
         <!-- Bump when the godot submodule or the natives package layout changes (deploy skips duplicates);
              reset to 0 when GodotVersion changes. NuGet normalizes a trailing .0 (4.7.0.0 publishes as 4.7.0). -->
-        <NativesRevision>3</NativesRevision>
+        <NativesRevision>4</NativesRevision>
         <TwoDogVersion>$(GodotVersion).$(TwoDogRevision)</TwoDogVersion>
         <NativesVersion>$(GodotVersion).$(NativesRevision)</NativesVersion>
         <!-- Mixed Avalonia versions fail at runtime, so bump in one place. The template consumes it via its

--- a/demos/showcase/showcase.2dog/Program.cs
+++ b/demos/showcase/showcase.2dog/Program.cs
@@ -18,7 +18,7 @@ internal static class Program
 
         // Content is resolved from the source project or published .pck.
         using var engine = new Engine("showcase", args: args);
-        using var godotInstance = engine.Start();
+        engine.Start();
         GD.Print("Hello from GodotSharp.");
         GD.Print("Scene Root: ", engine.Tree.CurrentScene.Name);
 
@@ -39,7 +39,7 @@ internal static class Program
 
         // Iteration() returns true when the engine wants to quit (window
         // closed, SceneTree.Quit(), --quit-after N, ...).
-        while (!godotInstance.Iteration())
+        while (!engine.Iteration())
         {
             var delta = (float)engine.Tree.Root.GetProcessDeltaTime();
             foreach (var cube in whiteCubes)

--- a/demos/showcase/showcase.blazor/Client/Pages/Home.razor
+++ b/demos/showcase/showcase.blazor/Client/Pages/Home.razor
@@ -28,6 +28,7 @@
         <button @onclick="TogglePause" disabled="@(!IsRunning)">@(_paused ? "Resume" : "Pause")</button>
         <button @onclick="() => _view!.StartAsync()" disabled="@(_view is null || IsRunning)">Start engine</button>
         <button @onclick="() => _view?.Quit()" disabled="@(!IsRunning)">Quit engine</button>
+        <button @onclick="RestartEngine" disabled="@(!IsRunning)">Restart engine</button>
     </aside>
 
     <main class="viewport">

--- a/demos/showcase/showcase.blazor/Client/Pages/Home.razor.cs
+++ b/demos/showcase/showcase.blazor/Client/Pages/Home.razor.cs
@@ -16,6 +16,7 @@ public partial class Home : ComponentBase
     private long _frames;
     private float _spinSpeed = 1.8f; // radians per second
     private bool _paused;
+    private bool _restartOnExit;
     private Node3D[] _whiteCubes = [];
     private static readonly Vector3 WhiteSpinAxis = new Vector3(1, 1, 0).Normalized();
 
@@ -69,11 +70,21 @@ public partial class Home : ComponentBase
         _ = InvokeAsync(StateHasChanged);
     }
 
-    private void OnExited()
+    private async Task OnExited()
     {
         _status = "Godot quit.";
         _whiteCubes = [];
         _paused = false;
+        if (!_restartOnExit || _view is null) return;
+        _restartOnExit = false;
+        await _view.StartAsync();
+    }
+
+    private void RestartEngine()
+    {
+        if (_view is null) return;
+        _restartOnExit = true;
+        _view.Quit();
     }
 
     private void OnFailed(Exception exception) => _status = $"Failed: {exception.Message}";

--- a/demos/showcase/showcase.web/Program.cs
+++ b/demos/showcase/showcase.web/Program.cs
@@ -5,7 +5,7 @@ namespace showcase.web;
 
 internal static class Program
 {
-    private static int Main(string[] args)
+    private static async Task<int> Main(string[] args)
     {
         Console.WriteLine("2dog web showcase starting...");
 
@@ -16,28 +16,24 @@ internal static class Program
         // args come from the JS shell (GODOT_CONFIG.args plus the
         // '--main-pack godot.pck' the engine loader prepends).
         var engine = new Engine("showcase.web", args: args);
-        engine.Start();
-
         try
         {
+            engine.Start();
             GD.Print("Hello from GodotSharp (browser).");
             GD.Print("Scene Root: ", engine.Tree.CurrentScene.Name);
 
             GodotApiSmoke.RunAll(engine.Tree);
+
+            // The browser loop owns the lifetime after Run() returns.
+            engine.Run();
         }
         catch (Exception exception)
         {
             Console.Error.WriteLine($"2DOG_WASM_SMOKE_FAILED: {exception}");
             JavaScriptBridge.Eval("document.documentElement.setAttribute('data-twodog-smoke', 'failed')");
-            // Browser ownership transfers to the engine only at Run(); this
-            // pre-loop failure still owns the started instance.
-            engine.Dispose();
+            await engine.DisposeAsync();
             throw;
         }
-
-        // Hands the loop to emscripten and returns immediately; the engine
-        // destroys itself when Godot requests quit. Do not dispose here.
-        engine.Run();
 
         // Marked only after Run() returns, so a failed loop installation
         // cannot report a passing smoke.

--- a/demos/showcase/showcase.webxr/Program.cs
+++ b/demos/showcase/showcase.webxr/Program.cs
@@ -6,7 +6,7 @@ namespace showcase.webxr;
 
 internal static class Program
 {
-    private static int Main(string[] args)
+    private static async Task<int> Main(string[] args)
     {
         Console.WriteLine("2dog webxr showcase starting...");
 
@@ -17,10 +17,9 @@ internal static class Program
         // args come from the JS shell (GODOT_CONFIG.args plus the
         // '--main-pack godot.pck' the engine loader prepends).
         var engine = new Engine("showcase.web", args: args);
-        engine.Start();
-
         try
         {
+            engine.Start();
             GD.Print("Hello from GodotSharp (browser).");
             GD.Print("Scene Root: ", engine.Tree.CurrentScene.Name);
 
@@ -32,20 +31,17 @@ internal static class Program
             {
                 throw new InvalidOperationException("WebXR interface is not registered");
             }
+
+            // The browser loop owns the lifetime after Run() returns.
+            engine.Run();
         }
         catch (Exception exception)
         {
             Console.Error.WriteLine($"2DOG_WASM_SMOKE_FAILED: {exception}");
             JavaScriptBridge.Eval("document.documentElement.setAttribute('data-twodog-smoke', 'failed')");
-            // Browser ownership transfers to the engine only at Run(); this
-            // pre-loop failure still owns the started instance.
-            engine.Dispose();
+            await engine.DisposeAsync();
             throw;
         }
-
-        // Hands the loop to emscripten and returns immediately; the engine
-        // destroys itself when Godot requests quit. Do not dispose here.
-        engine.Run();
 
         // Marked only after Run() returns, so a failed loop installation
         // cannot report a passing smoke.

--- a/demos/showcase/showcase.winforms/MainForm.cs
+++ b/demos/showcase/showcase.winforms/MainForm.cs
@@ -87,10 +87,10 @@ internal sealed class MainForm : Form
     // Application's preprocessing; harmless, since the loop yields as soon as anything is queued.
     private void OnApplicationIdle(object? sender, EventArgs e)
     {
-        while (_instance is { } instance && !PeekMessage(out _, 0, 0, 0, 0))
+        while (_instance is not null && _engine is { } engine && !PeekMessage(out _, 0, 0, 0, 0))
         {
             // Iteration() returns true when the engine wants to quit (SceneTree.Quit(), --quit-after N, ...).
-            if (instance.Iteration())
+            if (engine.Iteration())
             {
                 ShutdownEngine();
                 Close();
@@ -127,7 +127,6 @@ internal sealed class MainForm : Form
     {
         Application.Idle -= OnApplicationIdle;
         _pauseButton.Enabled = false;
-        _instance?.Dispose();
         _instance = null;
         _engine?.Dispose();
         _engine = null;

--- a/demos/showcase/showcase.winui/MainWindow.cs
+++ b/demos/showcase/showcase.winui/MainWindow.cs
@@ -119,10 +119,10 @@ internal sealed class MainWindow : Window
     {
         DispatcherQueue.TryEnqueue(DispatcherQueuePriority.Low, () =>
         {
-            if (_instance is not { } instance)
+            if (_instance is null || _engine is not { } engine)
                 return;
             // Iteration() returns true when the engine wants to quit (SceneTree.Quit(), --quit-after N, ...).
-            if (instance.Iteration())
+            if (engine.Iteration())
             {
                 ShutdownEngine();
                 Close();
@@ -176,7 +176,6 @@ internal sealed class MainWindow : Window
     private void ShutdownEngine()
     {
         _pauseButton.IsEnabled = false;
-        _instance?.Dispose();
         _instance = null;
         _engine?.Dispose();
         _engine = null;

--- a/docs/content/api-reference.md
+++ b/docs/content/api-reference.md
@@ -20,7 +20,7 @@ instance, or use the fixture classes when xUnit owns the process.
 
 | Type | Use it to |
 | --- | --- |
-| [`GodotInstance`](./api/godot-instance) | Pump or control the instance returned by `Engine.Start()` |
+| [`GodotInstance`](./api/godot-instance) | Access the borrowed compatibility handle returned by `Engine.Start()` |
 
 2dog adds `GodotInstance` to the GodotSharp API. Use the
 [Godot class reference](https://docs.godotengine.org/en/latest/classes/) for
@@ -51,13 +51,16 @@ test assembly so xUnit can discover them.
 
 ```csharp
 using var engine = new twodog.Engine("MyGame", args: args);
-using var godot = engine.Start();
+engine.Start();
 
-while (!godot.Iteration())
+while (!engine.Iteration())
 {
     // One frame has completed.
 }
 ```
 
-Dispose `GodotInstance` before its owning `Engine`. Only one classic instance
-can run in a process at a time; see [Single Godot Instance](./known-issues/single-instance).
+`Engine` owns the instance. Use `RequestQuit()` for graceful shutdown;
+`Completion` completes and `Exited` fires after teardown on every platform.
+Desktop `Dispose()` is synchronous; browser callers await `DisposeAsync()` or
+`Completion`. Start a new `Engine` only after completion. See
+[Single Godot Instance](./known-issues/single-instance).

--- a/docs/content/api/assembly-preloader.md
+++ b/docs/content/api/assembly-preloader.md
@@ -43,5 +43,5 @@ var projectDir = twodog.Engine.ResolveProjectDir();
 AssemblyPreloader.PreloadGameAssemblies(projectDir);
 
 using var engine = new twodog.Engine("MyGame", args: ["--headless"]);
-using var godot = engine.Start();
+engine.Start();
 ```

--- a/docs/content/api/engine.md
+++ b/docs/content/api/engine.md
@@ -76,6 +76,8 @@ public Task Completion { get; }
 Completes when this `Engine` reaches a terminal state. If `Start()` succeeded,
 that means the owned native instance has been destroyed and synchronous `Exited`
 handlers have returned. Asynchronous work started by those handlers is not awaited.
+Shutdown restores the host synchronization context before notifying `Exited`, so
+subsequent host awaits do not depend on Godot's stopped frame loop.
 
 ### `Exited`
 

--- a/docs/content/api/engine.md
+++ b/docs/content/api/engine.md
@@ -74,7 +74,8 @@ public Task Completion { get; }
 ```
 
 Completes when this `Engine` reaches a terminal state. If `Start()` succeeded,
-that means the owned native instance has been destroyed.
+that means the owned native instance has been destroyed and synchronous `Exited`
+handlers have returned. Asynchronous work started by those handlers is not awaited.
 
 ### `Exited`
 

--- a/docs/content/api/engine.md
+++ b/docs/content/api/engine.md
@@ -8,7 +8,7 @@ description: "API reference for twodog.Engine, which configures, starts, and own
 Configures, starts, and owns one embedded Godot instance.
 
 ```csharp
-public class Engine : IDisposable
+public class Engine : IDisposable, IAsyncDisposable
 ```
 
 **Package:** `2dog.engine`  
@@ -67,6 +67,24 @@ public static string? LoadedNativePath { get; }
 
 Returns the full path of the loaded desktop `libgodot`, when known.
 
+### `Completion`
+
+```csharp
+public Task Completion { get; }
+```
+
+Completes when this `Engine` reaches a terminal state. If `Start()` succeeded,
+that means the owned native instance has been destroyed.
+
+### `Exited`
+
+```csharp
+public event Action? Exited;
+```
+
+Fires once after a successfully started instance is destroyed. `Completion`
+also completes for an `Engine` disposed before it starts, but `Exited` does not fire.
+
 ## Methods
 
 ### `Start`
@@ -75,9 +93,28 @@ Returns the full path of the loaded desktop `libgodot`, when known.
 public GodotInstance Start()
 ```
 
-Starts Godot and the project's `run/main_scene`, then returns its running
-instance. Starting a second classic instance before disposing the first throws
+Starts Godot and the project's `run/main_scene`, then returns a borrowed
+`GodotInstance` compatibility handle. `Engine` owns the instance; do not dispose
+the handle. Starting another instance before completion throws
 `InvalidOperationException`.
+
+### `Iteration`
+
+```csharp
+public bool Iteration()
+```
+
+Processes one main-loop frame. Returns `true` when Godot requests exit.
+Dispose the engine after the pump stops. Calling `Iteration()` recursively,
+or while `Run()` owns the pump, throws `InvalidOperationException`.
+
+### `RequestQuit`
+
+```csharp
+public void RequestQuit()
+```
+
+Requests a graceful quit. Repeated requests are harmless.
 
 ### `Run`
 
@@ -97,8 +134,34 @@ Runs the main loop after `Start()`.
 public void Dispose()
 ```
 
-Stops and destroys the instance owned by this engine. Dispose the
-[`GodotInstance`](./godot-instance) first.
+Stops and destroys the owned instance synchronously on desktop. In a browser,
+`Dispose()` requests shutdown and returns before teardown; use `DisposeAsync()`
+or await `Completion`.
+
+### `DisposeAsync`
+
+```csharp
+public ValueTask DisposeAsync()
+```
+
+Requests shutdown and waits for teardown. Prefer this in browser hosts.
+
+Lifecycle calls and Godot object access belong on the thread that called
+`Start()`. Calls from another thread are rejected; dispatch them to the host's
+engine thread. Disposal from a game callback is deferred until the native
+frame returns. Do not synchronously wait for `Completion` inside that callback.
+
+### `WebExitRuntimeOnQuit`
+
+```csharp
+public static bool WebExitRuntimeOnQuit { get; set; }
+```
+
+Defaults to `false` in a browser: quitting destroys Godot and keeps .NET alive
+so any host can start another engine. Standalone pages may set it to `true`
+to terminate the entire WebAssembly runtime on quit. Blazor keeps it `false`.
+Browser restarts require a fresh canvas and host configuration before `Start()`;
+`GodotView` handles those browser resources automatically.
 
 ### `ResolveContent`
 
@@ -145,9 +208,9 @@ internal static class Program
     private static void Main(string[] args)
     {
         using var engine = new Engine("MyGame", args: args);
-        using var godot = engine.Start();
+        engine.Start();
 
-        while (!godot.Iteration())
+        while (!engine.Iteration())
         {
             // One frame has completed.
         }

--- a/docs/content/api/fixture-base.md
+++ b/docs/content/api/fixture-base.md
@@ -36,7 +36,7 @@ public class OpenGl3Fixture()
 | Property | Type | Description |
 | --- | --- | --- |
 | `Engine` | `twodog.Engine` | Engine owned by the fixture |
-| `GodotInstance` | `Godot.GodotInstance` | Running native instance |
+| `GodotInstance` | `Godot.GodotInstance` | Borrowed compatibility handle |
 | `Tree` | `Godot.SceneTree` | Active scene tree |
 
 ## `Dispose`
@@ -45,8 +45,8 @@ public class OpenGl3Fixture()
 public void Dispose()
 ```
 
-Disposes `GodotInstance`, then `Engine`. Let the test framework call this
-through its fixture lifetime.
+Disposes the owning `Engine`. Let the test framework call this through its
+fixture lifetime.
 
 ## Custom xUnit Collection
 

--- a/docs/content/api/godot-instance.md
+++ b/docs/content/api/godot-instance.md
@@ -1,11 +1,11 @@
 ---
 title: Godot.GodotInstance
-description: "API reference for Godot.GodotInstance, the handle returned by Engine.Start(): Iteration, IsStarted, focus and pause control, and disposal."
+description: "API reference for Godot.GodotInstance, the borrowed compatibility handle returned by Engine.Start()."
 ---
 
 # `Godot.GodotInstance`
 
-Controls the running Godot instance returned by [`twodog.Engine.Start()`](./engine#start).
+Borrowed compatibility handle returned by [`twodog.Engine.Start()`](./engine#start).
 
 ```csharp
 public class GodotInstance : IDisposable
@@ -15,11 +15,12 @@ public class GodotInstance : IDisposable
 **Namespace:** `Godot`
 
 This class is one of the few differences from stock Godot, where it's not exposed.
+Its `Engine` owns the native instance and its lifecycle.
 
 Create this object through `twodog.Engine.Start()` rather than its low-level static
 factory methods.
 
-## Methods
+## Compatibility Methods
 
 ### `Iteration`
 
@@ -27,10 +28,11 @@ factory methods.
 public bool Iteration()
 ```
 
-Processes one main-loop frame. Returns `true` when Godot wants to quit.
+Processes one main-loop frame. Returns `true` when Godot wants to quit. New host
+code should call `Engine.Iteration()`.
 
 ```csharp
-while (!godot.Iteration())
+while (!engine.Iteration())
 {
     // One frame has completed.
 }
@@ -64,15 +66,8 @@ public void Resume()
 Notify Godot that the host application has paused or resumed. These lifecycle
 hooks are useful when another application framework owns the outer window.
 
-### `Dispose`
-
-```csharp
-public void Dispose()
-```
-
-Shuts down the native instance. Dispose it before its owning `Engine`.
-
 ::: warning Choose one loop owner
-Call `Iteration()` yourself or call `Engine.Run()`. Do not use both for the same
-instance.
+Call `Engine.Iteration()` yourself or call `Engine.Run()`. Do not use both for
+the same instance. Use `Engine.RequestQuit()`, `Completion`, `Exited`, and engine
+disposal for lifecycle control; do not dispose this borrowed handle.
 :::

--- a/docs/content/concepts.md
+++ b/docs/content/concepts.md
@@ -50,7 +50,7 @@ After startup, the full GodotSharp API is accessible:
 
 ```csharp
 using var engine = new Engine("MyGame", args: args);
-using var godot = engine.Start();
+GodotInstance godot = engine.Start(); // Borrowed compatibility handle.
 
 // Access the scene tree
 SceneTree tree = engine.Tree;
@@ -70,7 +70,7 @@ var physics = PhysicsServer3D.Singleton;
 Unlike traditional Godot, the host explicitly pumps Godot in its main loop:
 
 ```csharp
-while (!godot.Iteration())
+while (!engine.Iteration())
 {
     // Godot processes physics, rendering, input, and your frame logic here.
     if (someCondition)
@@ -78,11 +78,15 @@ while (!godot.Iteration())
 }
 ```
 
-`Iteration()` returns `true` when Godot wants to quit, such as when the window closes.
+`Engine` owns the running instance. `Iteration()` returns `true` when Godot
+wants to quit, such as when the window closes; `RequestQuit()` asks it to stop.
+After teardown, `Completion` completes and `Exited` fires on every platform.
+Desktop disposal is synchronous; browser disposal is asynchronous.
 
 ## Single Instance only (for now.)
 
-Only one Godot instance can run per assembly load context at a time. Sequential
-restart is supported. See [Single Godot Instance](./known-issues/single-instance)
+Only one Godot instance can run per assembly load context at a time. For a
+sequential restart, wait for completion and create a new `Engine`. See
+[Single Godot Instance](./known-issues/single-instance)
 for examples and an experimental isolated-hosting path to kind of get multiple engines
 after all.

--- a/docs/content/hosts/blazor.md
+++ b/docs/content/hosts/blazor.md
@@ -93,13 +93,15 @@ client takes over.
 | `Started` | The engine runs and its scene tree is available. |
 | `OnFrame` | Called once per engine frame after the iteration; keep it cheap. |
 | `AutoStart` / `StartAsync()` | Start after the first render (default), or later from your own code/button. |
-| `Quit()` / `Exited` | Asks Godot to quit; after its asynchronous teardown the instance is destroyed and `Exited` fires. Blazor keeps running. |
+| `Quit()` / `Exited` | Calls `Engine.RequestQuit()`; after asynchronous teardown `Engine.Completion` completes and `Exited` fires. Blazor keeps running. |
 | `CanStart` / `Lifetime` | Whether `StartAsync()` would start now; how many engines the view started. |
 | `Failed` / `Error` | Starting the engine failed; the view shows the message. |
 | `Resize` | `Container` (default: the canvas follows its element), `Project` (the project's window size), `FullWindow`. |
 
-One engine runs at a time. After `Quit()` completes, `StartAsync()` starts a
-new engine: `GodotView` renders a fresh `<canvas>` for it, because a browser
+`GodotView` owns its `Engine`; the `GodotInstance` returned by `Start()` is only
+a borrowed compatibility handle. Disposing the view awaits browser teardown.
+One engine runs at a time. After the current engine's completion, `StartAsync()`
+creates a new engine and renders a fresh `<canvas>` for it, because a browser
 hands out one WebGL context per canvas element for the element's whole life.
 The game assembly is not reloaded: Godot objects kept in static fields are
 disposed with the first engine, see

--- a/docs/content/hosts/generic.md
+++ b/docs/content/hosts/generic.md
@@ -40,12 +40,12 @@ internal static class Program
     private static void Main(string[] args)
     {
         using var engine = new Engine("MyGame", args: args);
-        using var godot = engine.Start();
+        engine.Start();
 
         if (engine.Tree.CurrentScene is { } scene)
             GD.Print($"2dog is running '{scene.Name}'!");
 
-        while (!godot.Iteration())
+        while (!engine.Iteration())
         {
             // Your per-frame logic here.
         }
@@ -53,8 +53,11 @@ internal static class Program
 }
 ```
 
-`Start()` runs `run/main_scene`, and `args` reach Godot unchanged. The `using`
-declarations dispose the instance and engine in the required order.
+`Engine` owns the instance. `Start()` runs `run/main_scene`, returns a borrowed
+`GodotInstance` compatibility handle, and passes `args` to Godot unchanged.
+Pump frames with `Engine.Iteration()`, and call `Engine.RequestQuit()` to request
+a graceful exit. `Completion` completes and `Exited` fires after teardown on
+every platform. On desktop, disposing `Engine` completes teardown synchronously.
 
 Prefer a callback? `engine.Run(perFrame)` iterates until quit and calls your
 delegate once per frame.
@@ -130,5 +133,6 @@ game and plugin assemblies from disk through hostfxr.
 
 ## Limitations
 
-- A normal host supports one active engine at a time. Disposing it permits a
-  sequential restart; see [Single Godot Instance](/known-issues/single-instance).
+- A normal host supports one active engine at a time. After completion, create
+  a new `Engine` for a sequential restart; see
+  [Single Godot Instance](/known-issues/single-instance).

--- a/docs/content/hosts/web.md
+++ b/docs/content/hosts/web.md
@@ -64,14 +64,22 @@ using Engine = twodog.Engine;
 
 internal static class Program
 {
-    private static int Main(string[] args)
+    private static async Task<int> Main(string[] args)
     {
         Engine.RegisterWebPluginsInitializer(TwoDogWebBoot.PluginsInitializer());
 
         var engine = new Engine("MyGame", args: args);
-        engine.Start();
-        GD.Print("2dog is running in the browser!");
-        engine.Run();
+        try
+        {
+            engine.Start();
+            GD.Print("2dog is running in the browser!");
+            engine.Run();
+        }
+        catch
+        {
+            await engine.DisposeAsync();
+            throw;
+        }
         return 0;
     }
 }
@@ -85,6 +93,15 @@ The browser host differs from the [generic host](./generic) in three ways:
    `--main-pack`.
 3. It calls `Run()` instead of `Iteration()`. `Run()` hands the frame loop to
    Emscripten and returns immediately; `Run(perFrame)` adds host-side frame work.
+
+`Engine` owns the instance returned by `Start()`. Call `RequestQuit()` to stop
+it. Browser teardown is asynchronous: await `Completion` or `DisposeAsync()`;
+`Exited` fires after teardown. These lifecycle members are also available on
+desktop, where `Dispose()` completes teardown synchronously. The runtime stays
+alive by default; start again only after completion, with a new `Engine` and
+fresh canvas configuration. Return from `Main()` after installing the loop:
+the page shell awaits it before hiding the loading overlay. Await teardown
+from later host callbacks, rather than keeping `Main()` pending until quit.
 
 ## Project Setup
 

--- a/docs/content/known-issues/single-instance.md
+++ b/docs/content/known-issues/single-instance.md
@@ -10,28 +10,35 @@ a second instance throws `InvalidOperationException`:
 
 ```csharp
 using var engine1 = new Engine("MyGame");
-using var godot1 = engine1.Start();
+engine1.Start();
 
 using var engine2 = new Engine("MyGame");
-using var godot2 = engine2.Start(); // Throws InvalidOperationException.
+engine2.Start(); // Throws InvalidOperationException.
 ```
 
 Sequential restart is supported in packages based on Godot 4.7 and later,
 including the browser: the [Blazor host](/hosts/blazor) restarts on a fresh
-canvas, and a web host that keeps the runtime alive
-(`Engine.WebExitRuntimeOnQuit = false`) can start a new engine after `Exited`.
-Dispose both the running instance and its engine before starting another:
+canvas, and web hosts keep the runtime alive by default
+(`Engine.WebExitRuntimeOnQuit = false`). Any host can start a new engine after
+`Completion` completes and `Exited` fires. `Engine` owns its instance; the
+`GodotInstance` returned by `Start()` is a borrowed compatibility handle.
+
+On desktop, dispose the current engine before creating another:
 
 ```csharp
-var engine = new Engine("MyGame");
-var godot = engine.Start();
-
-godot.Dispose();
-engine.Dispose();
+using (var engine = new Engine("MyGame"))
+{
+    engine.Start();
+    engine.Run();
+} // Synchronous teardown.
 
 using var nextEngine = new Engine("MyGame");
-using var nextGodot = nextEngine.Start();
+nextEngine.Start();
 ```
+
+In a browser, call `RequestQuit()` while `Run()` pumps frames and await
+`Completion`, or call `DisposeAsync()`
+before creating the new `Engine`; browser teardown is asynchronous.
 
 This allows xUnit collections to use fresh engines sequentially in one test
 process. Collections that share an engine must disable parallelization; see

--- a/templates/twodog/Company.Product1.2dog/Program.cs
+++ b/templates/twodog/Company.Product1.2dog/Program.cs
@@ -12,7 +12,7 @@ internal static class Program
         // The default constructor finds raw project content during development
         // and the exe-adjacent .pck after publish. Arguments are forwarded to Godot.
         using var engine = new Engine("Company.Product1", args: args);
-        using var godot = engine.Start();
+        engine.Start();
 
         if (engine.Tree.CurrentScene is { } scene)
             GD.Print($"2dog is running '{scene.Name}'!");
@@ -21,7 +21,7 @@ internal static class Program
         Console.WriteLine("Close the window to quit.");
 
         // Iteration() returns true when Godot wants to quit.
-        while (!godot.Iteration())
+        while (!engine.Iteration())
         {
             // Your per-frame logic here
         }

--- a/templates/twodog/Company.Product1.tests/BasicTests.cs
+++ b/templates/twodog/Company.Product1.tests/BasicTests.cs
@@ -29,7 +29,7 @@ public class BasicTests(HeadlessFixture godot)
     {
         // Arrange & Act
         godot.Tree.Root.PhysicsInterpolationMode = Node.PhysicsInterpolationModeEnum.Off;
-        godot.GodotInstance.Iteration();
+        godot.Engine.Iteration();
 
         // Assert - if we get here without crashing, test passes
         Assert.True(true);

--- a/templates/twodog/Company.Product1.web/Program.cs
+++ b/templates/twodog/Company.Product1.web/Program.cs
@@ -3,7 +3,7 @@ using Engine = twodog.Engine;
 
 internal static class Program
 {
-    private static int Main(string[] args)
+    private static async Task<int> Main(string[] args)
     {
         Console.WriteLine("TPLRAWNAME (web) starting...");
 
@@ -15,14 +15,19 @@ internal static class Program
         // args come from the page's GODOT_CONFIG.args plus the
         // '--main-pack godot.pck' the engine loader prepends.
         var engine = new Engine("TPLRAWNAME", args: args);
-        engine.Start();
-
-        GD.Print("2dog is running in the browser!");
-        GD.Print("Scene Root: ", engine.Tree.CurrentScene.Name);
-
-        // Hands the loop to emscripten and returns immediately; the engine
-        // destroys itself when Godot requests quit. Do not dispose here.
-        engine.Run();
+        try
+        {
+            engine.Start();
+            GD.Print("2dog is running in the browser!");
+            GD.Print("Scene Root: ", engine.Tree.CurrentScene.Name);
+            // The browser loop owns the lifetime after Run() returns.
+            engine.Run();
+        }
+        catch
+        {
+            await engine.DisposeAsync();
+            throw;
+        }
 
         return 0;
     }

--- a/templates/twodog/Company.Product1.webxr/Program.cs
+++ b/templates/twodog/Company.Product1.webxr/Program.cs
@@ -3,7 +3,7 @@ using Engine = twodog.Engine;
 
 internal static class Program
 {
-    private static int Main(string[] args)
+    private static async Task<int> Main(string[] args)
     {
         Console.WriteLine("TPLRAWNAME (webxr) starting...");
 
@@ -15,14 +15,19 @@ internal static class Program
         // args come from the page's GODOT_CONFIG.args plus the
         // '--main-pack godot.pck' the engine loader prepends.
         var engine = new Engine("TPLRAWNAME", args: args);
-        engine.Start();
-
-        GD.Print("2dog is running in the browser!");
-        GD.Print("Scene Root: ", engine.Tree.CurrentScene.Name);
-
-        // Hands the loop to emscripten and returns immediately; the engine
-        // destroys itself when Godot requests quit. Do not dispose here.
-        engine.Run();
+        try
+        {
+            engine.Start();
+            GD.Print("2dog is running in the browser!");
+            GD.Print("Scene Root: ", engine.Tree.CurrentScene.Name);
+            // The browser loop owns the lifetime after Run() returns.
+            engine.Run();
+        }
+        catch
+        {
+            await engine.DisposeAsync();
+            throw;
+        }
 
         return 0;
     }

--- a/templates/twodog/Company.Product1.winforms/MainForm.cs
+++ b/templates/twodog/Company.Product1.winforms/MainForm.cs
@@ -83,10 +83,10 @@ internal sealed class MainForm : Form
     // Application's preprocessing; harmless, since the loop yields as soon as anything is queued.
     private void OnApplicationIdle(object? sender, EventArgs e)
     {
-        while (_instance is { } instance && !PeekMessage(out _, 0, 0, 0, 0))
+        while (_instance is not null && _engine is { } engine && !PeekMessage(out _, 0, 0, 0, 0))
         {
             // Iteration() returns true when the engine wants to quit (SceneTree.Quit(), --quit-after N, ...).
-            if (instance.Iteration())
+            if (engine.Iteration())
             {
                 ShutdownEngine();
                 Close();
@@ -123,7 +123,6 @@ internal sealed class MainForm : Form
     {
         Application.Idle -= OnApplicationIdle;
         _pauseButton.Enabled = false;
-        _instance?.Dispose();
         _instance = null;
         _engine?.Dispose();
         _engine = null;

--- a/templates/twodog/Company.Product1.winui/MainWindow.cs
+++ b/templates/twodog/Company.Product1.winui/MainWindow.cs
@@ -107,10 +107,10 @@ internal sealed class MainWindow : Window
     {
         DispatcherQueue.TryEnqueue(DispatcherQueuePriority.Low, () =>
         {
-            if (_instance is not { } instance)
+            if (_instance is null || _engine is not { } engine)
                 return;
             // Iteration() returns true when the engine wants to quit (SceneTree.Quit(), --quit-after N, ...).
-            if (instance.Iteration())
+            if (engine.Iteration())
             {
                 ShutdownEngine();
                 Close();
@@ -157,7 +157,6 @@ internal sealed class MainWindow : Window
     private void ShutdownEngine()
     {
         _pauseButton.IsEnabled = false;
-        _instance?.Dispose();
         _instance = null;
         _engine?.Dispose();
         _engine = null;

--- a/twodog.avalonia/GodotSession.cs
+++ b/twodog.avalonia/GodotSession.cs
@@ -366,7 +366,7 @@ public sealed class GodotSession : IDisposable
         try
         {
             ApplyPendingResize();
-            if (_instance.Iteration())
+            if (Engine.Iteration())
             {
                 StopPump();
                 QuitRequested?.Invoke(this, EventArgs.Empty);
@@ -408,7 +408,6 @@ public sealed class GodotSession : IDisposable
 
         // Dispose before process exit: on Windows the engine must be gone before the
         // ProcessExit libgodot unload runs (see Engine's static constructor).
-        _instance?.Dispose();
         _instance = null;
         _engine?.Dispose();
         _engine = null;

--- a/twodog.avalonia/Presentation/IPresenter.cs
+++ b/twodog.avalonia/Presentation/IPresenter.cs
@@ -17,7 +17,7 @@ internal interface IPresenter : IDisposable
     /// <summary>Permanently unable to present; the session may swap in a fallback.</summary>
     bool Failed { get; }
 
-    /// <summary>Called once per engine frame, after <c>GodotInstance.Iteration()</c>.</summary>
+    /// <summary>Called once per engine frame, after <c>Engine.Iteration()</c>.</summary>
     void PresentFrame();
 
     /// <summary>Called when the control's size or scaling changed (the session has already

--- a/twodog.blazor/GodotView.razor.cs
+++ b/twodog.blazor/GodotView.razor.cs
@@ -116,7 +116,9 @@ public partial class GodotView : ComponentBase, IAsyncDisposable
     }
 
     /// <summary>Starts the engine; a no-op while one is running or starting. Works again after <see cref="Exited"/>.</summary>
-    public async Task StartAsync()
+    public Task StartAsync() => InvokeAsync(StartCoreAsync);
+
+    private async Task StartCoreAsync()
     {
         Engine? startedEngine = null;
         Exception? failure = null;
@@ -168,7 +170,7 @@ public partial class GodotView : ComponentBase, IAsyncDisposable
             Engine = engine;
             try
             {
-                engine.Exited += () => _ = CompleteExitAsync(engine);
+                engine.Exited += () => _ = InvokeAsync(() => CompleteExitAsync(engine));
                 engine.Start();
                 _lifetime++;
                 // Hands the loop to emscripten and returns; the engine destroys itself on quit.
@@ -384,7 +386,7 @@ public partial class GodotView : ComponentBase, IAsyncDisposable
     /// <summary>Focuses the canvas so keyboard input reaches Godot.</summary>
     public ValueTask FocusAsync() => _canvas.FocusAsync();
 
-    public ValueTask DisposeAsync() => new(_disposeTask ??= DisposeCoreAsync());
+    public ValueTask DisposeAsync() => new(_disposeTask ??= InvokeAsync(DisposeCoreAsync));
 
     private async Task DisposeCoreAsync()
     {

--- a/twodog.blazor/GodotView.razor.cs
+++ b/twodog.blazor/GodotView.razor.cs
@@ -23,7 +23,10 @@ public enum GodotCanvasResize
 /// </summary>
 public partial class GodotView : ComponentBase, IAsyncDisposable
 {
+    private static readonly SemaphoreSlim EngineLease = new(1, 1);
     private readonly string _viewId = Guid.NewGuid().ToString("N");
+    private readonly SemaphoreSlim _lifecycle = new(1, 1);
+    private readonly CancellationTokenSource _disposeCancellation = new();
     private int _lifetime;
     // Keys the canvas element. Bumped only after an exit: changing it mid-lifetime would make the next render
     // replace the canvas Godot draws into (the first lifetime went black that way, its counter also being the key).
@@ -33,6 +36,8 @@ public partial class GodotView : ComponentBase, IAsyncDisposable
     private IJSObjectReference? _module;
     private bool _disposed;
     private bool _starting;
+    private bool _hasEngineLease;
+    private Task? _disposeTask;
 
     private string CanvasId => $"twodog-canvas-{_viewId}-{_canvasGeneration}";
 
@@ -113,15 +118,19 @@ public partial class GodotView : ComponentBase, IAsyncDisposable
     /// <summary>Starts the engine; a no-op while one is running or starting. Works again after <see cref="Exited"/>.</summary>
     public async Task StartAsync()
     {
-        if (IsRunning || _starting || _disposed) return;
-        _starting = true;
-        Error = null;
-        StateHasChanged();
+        Engine? startedEngine = null;
+        Exception? failure = null;
+        await _lifecycle.WaitAsync();
         try
         {
+            if (IsRunning || _disposed) return;
+            _starting = true;
+            Error = null;
+            StateHasChanged();
+
             if (_canvasRendered is { } rendered)
             {
-                await rendered.Task;
+                await rendered.Task.WaitAsync(_disposeCancellation.Token);
                 _canvasRendered = null;
             }
 
@@ -129,11 +138,16 @@ public partial class GodotView : ComponentBase, IAsyncDisposable
                 throw new ArgumentException($"{nameof(GodotView)}: {nameof(PluginsInitializer)} is required " +
                                             "(pass TwoDogWebBoot.PluginsInitializer() from your game project).");
 
-            _module ??= await Js.InvokeAsync<IJSObjectReference>("import", "./_content/2dog.blazor/2dog.blazor.js");
+            await EngineLease.WaitAsync(_disposeCancellation.Token);
+            _hasEngineLease = true;
+            if (_disposed) return;
+
+            _module ??= await Js.InvokeAsync<IJSObjectReference>("import", _disposeCancellation.Token,
+                "./_content/2dog.blazor/2dog.blazor.js");
 
             // The pack is copied into the wasm file system under its own name; Godot opens it from there.
             var packName = Path.GetFileName(PackUrl);
-            await _module.InvokeVoidAsync("prepare", _canvas, new
+            await _module.InvokeVoidAsync("prepare", _disposeCancellation.Token, _canvas, new
             {
                 packUrl = PackUrl,
                 packName,
@@ -151,69 +165,239 @@ public partial class GodotView : ComponentBase, IAsyncDisposable
             if (Args is not null) args.AddRange(Args);
 
             var engine = new Engine(Project, args: args.ToArray());
-            engine.Exited += OnEngineExited;
-            engine.Start();
             Engine = engine;
-            _lifetime++;
-            // Hands the loop to emscripten and returns; the engine destroys itself on quit.
-            engine.Run(() => OnFrame?.Invoke());
-
-            await Started.InvokeAsync(engine);
+            try
+            {
+                engine.Exited += () => _ = CompleteExitAsync(engine);
+                engine.Start();
+                _lifetime++;
+                // Hands the loop to emscripten and returns; the engine destroys itself on quit.
+                engine.Run(() => { if (!_disposed) OnFrame?.Invoke(); });
+                startedEngine = engine;
+            }
+            catch
+            {
+                await StopEngineAsync(engine);
+                throw;
+            }
+        }
+        catch (OperationCanceledException) when (_disposed)
+        {
+            await CleanupStartAttemptAsync();
         }
         catch (Exception e)
         {
             // An exception escaping OnAfterRenderAsync takes the whole Blazor app down; report instead.
             Console.Error.WriteLine($"{nameof(GodotView)}: {e}");
             Error = e;
-            Engine = null;
-            StateHasChanged();
-            await Failed.InvokeAsync(e);
+            failure = e;
+            try
+            {
+                await CleanupStartAttemptAsync();
+            }
+            catch (Exception cleanupError)
+            {
+                Console.Error.WriteLine($"{nameof(GodotView)}: startup cleanup failed: {cleanupError}");
+                failure = new AggregateException(e, cleanupError);
+                Error = failure;
+            }
         }
         finally
         {
             _starting = false;
+            if (_disposed)
+            {
+                try
+                {
+                    await CleanupStartAttemptAsync();
+                }
+                catch (Exception e)
+                {
+                    Console.Error.WriteLine($"{nameof(GodotView)}: disposal cleanup failed: {e}");
+                }
+            }
+            _lifecycle.Release();
+        }
+
+        if (startedEngine is not null && !_disposed && ReferenceEquals(Engine, startedEngine))
+        {
+            try
+            {
+                await Started.InvokeAsync(startedEngine);
+            }
+            catch (Exception e)
+            {
+                Console.Error.WriteLine($"{nameof(GodotView)}: {nameof(Started)} callback failed: {e}");
+                failure = e;
+                Error = e;
+                await _lifecycle.WaitAsync();
+                try
+                {
+                    if (ReferenceEquals(Engine, startedEngine))
+                        await StopEngineAsync(startedEngine);
+                }
+                catch (Exception cleanupError)
+                {
+                    Console.Error.WriteLine($"{nameof(GodotView)}: callback cleanup failed: {cleanupError}");
+                    failure = new AggregateException(e, cleanupError);
+                    Error = failure;
+                }
+                finally
+                {
+                    _lifecycle.Release();
+                }
+            }
+        }
+
+        if (failure is not null && !_disposed)
+        {
+            StateHasChanged();
+            await Failed.InvokeAsync(failure);
         }
     }
 
-    private void OnEngineExited()
+    private async Task CleanupStartAttemptAsync()
     {
-        Engine = null;
+        if (Engine is { } engine)
+        {
+            await StopEngineAsync(engine);
+            return;
+        }
+
+        try
+        {
+            await CleanupJsAsync();
+        }
+        finally
+        {
+            ReleaseEngineLease();
+        }
+    }
+
+    private async Task<bool> StopEngineAsync(Engine? engine)
+    {
+        var stoppedCurrent = false;
+        if (engine is not null)
+        {
+            try
+            {
+                await engine.DisposeAsync();
+            }
+            finally
+            {
+                if (ReferenceEquals(Engine, engine))
+                {
+                    stoppedCurrent = true;
+                    Engine = null;
+                    try
+                    {
+                        await CleanupJsAsync();
+                    }
+                    finally
+                    {
+                        ReleaseEngineLease();
+                    }
+                }
+            }
+        }
+
+        if (!stoppedCurrent || _disposed) return false;
+
         // Godot keeps one WebGL context per canvas element; the next lifetime gets a new element.
         _canvasGeneration++;
-        _canvasRendered = new TaskCompletionSource();
-        _ = InvokeAsync(async () =>
+        _canvasRendered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        StateHasChanged();
+        return true;
+    }
+
+    private async Task CleanupJsAsync()
+    {
+        if (_module is null) return;
+        var module = _module;
+        _module = null;
+        try
         {
-            StateHasChanged();
-            await Exited.InvokeAsync();
-        });
+            await module.InvokeVoidAsync("release", _canvas);
+        }
+        catch (JSDisconnectedException)
+        {
+            // Page is going away.
+        }
+        catch (JSException e)
+        {
+            Console.Error.WriteLine($"{nameof(GodotView)}: JavaScript release failed: {e.Message}");
+        }
+
+        try
+        {
+            await module.DisposeAsync();
+        }
+        catch (JSDisconnectedException)
+        {
+            // Page is going away.
+        }
+        catch (JSException e)
+        {
+            Console.Error.WriteLine($"{nameof(GodotView)}: JavaScript module disposal failed: {e.Message}");
+        }
+    }
+
+    private void ReleaseEngineLease()
+    {
+        if (!_hasEngineLease) return;
+        _hasEngineLease = false;
+        EngineLease.Release();
     }
 
     /// <summary>Asks Godot to quit (like closing its window); teardown completes asynchronously, then <see cref="Exited"/> fires.</summary>
     public void Quit()
     {
         if (!IsRunning) return;
-        Engine!.Tree.Quit();
+        Engine!.RequestQuit();
+    }
+
+    private async Task CompleteExitAsync(Engine engine)
+    {
+        var notifyExited = false;
+        try
+        {
+            await _lifecycle.WaitAsync();
+            try
+            {
+                if (!ReferenceEquals(Engine, engine)) return;
+                notifyExited = await StopEngineAsync(engine);
+            }
+            finally
+            {
+                _lifecycle.Release();
+            }
+
+            if (notifyExited)
+                await Exited.InvokeAsync();
+        }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine($"{nameof(GodotView)}: exit handling failed: {e}");
+        }
     }
 
     /// <summary>Focuses the canvas so keyboard input reaches Godot.</summary>
     public ValueTask FocusAsync() => _canvas.FocusAsync();
 
-    public async ValueTask DisposeAsync()
+    public ValueTask DisposeAsync() => new(_disposeTask ??= DisposeCoreAsync());
+
+    private async Task DisposeCoreAsync()
     {
-        if (_disposed) return;
         _disposed = true;
-        Quit();
-        if (_module is not null)
+        _disposeCancellation.Cancel();
+        await _lifecycle.WaitAsync();
+        try
         {
-            try
-            {
-                await _module.InvokeVoidAsync("release", _canvas);
-                await _module.DisposeAsync();
-            }
-            catch (JSDisconnectedException)
-            {
-                // Page is going away.
-            }
+            await CleanupStartAttemptAsync();
+        }
+        finally
+        {
+            _lifecycle.Release();
         }
     }
 }

--- a/twodog.blazor/README.md
+++ b/twodog.blazor/README.md
@@ -22,3 +22,8 @@ JavaScript interop layer between them.
 The view needs the `2dog.engine` and `2dog.browser-wasm` packages in the Blazor
 WebAssembly project; 2dog's Blazor host template wires everything up
 (`dnx 2dog add --blazor`). See https://2dog.dev/hosts/blazor.
+
+`GodotView` owns its `Engine`, and the engine owns the Godot instance. Quitting
+uses `Engine.RequestQuit()`; browser teardown is asynchronous, with
+`Completion` and `Exited` signaling its end. A restart creates a new `Engine`
+only after completion.

--- a/twodog.blazor/wwwroot/2dog.blazor.js
+++ b/twodog.blazor/wwwroot/2dog.blazor.js
@@ -2,7 +2,8 @@
 // Mirrors what Godot's engine.js does before callMain: file system init, pack preload, canvas/config handoff.
 
 const observers = new WeakMap();
-let fsReady = false;
+const preparations = new WeakMap();
+let fsInitialization;
 
 function runtimeModule() {
     const runtime = globalThis.Blazor?.runtime
@@ -45,6 +46,9 @@ function observeContainer(canvas) {
  */
 export async function prepare(canvas, options) {
     const Module = runtimeModule();
+    release(canvas);
+    const controller = new AbortController();
+    preparations.set(canvas, controller);
     // Godot fetches its audio worklets through Module.locateFile, which the .NET loader aims at _framework/;
     // the 2dog build publishes them at the site root, where Blazor may have fingerprinted them - import.meta.resolve
     // applies the page's import map (a plain fetch would miss it).
@@ -59,21 +63,32 @@ export async function prepare(canvas, options) {
         Module.__twodogLocateFile = true;
     }
 
-    if (!fsReady) {
-        await Module.initFS(['/userfs']);
-        fsReady = true;
+    try {
+        // An interop cancellation can release the lease while initFS is still running.
+        // The next view must join that initialization instead of mounting IDBFS twice.
+        await (fsInitialization ??= Module.initFS(['/userfs']).catch((error) => {
+            fsInitialization = undefined;
+            throw error;
+        }));
+        controller.signal.throwIfAborted();
+        const response = await fetch(resolveUrl(options.packUrl), { signal: controller.signal });
+        if (!response.ok) {
+            throw new Error(`2dog.blazor: could not load the game pack '${options.packUrl}' (HTTP ${response.status}).`);
+        }
+        const pack = await response.arrayBuffer();
+        // Cancelling .NET JS interop does not cancel this JavaScript promise. A released
+        // view must never reconfigure the runtime after another view acquires the lease.
+        controller.signal.throwIfAborted();
+        Module.copyToFS(options.packName, pack);
+    } finally {
+        if (preparations.get(canvas) === controller) {
+            preparations.delete(canvas);
+        }
     }
-
-    const response = await fetch(resolveUrl(options.packUrl));
-    if (!response.ok) {
-        throw new Error(`2dog.blazor: could not load the game pack '${options.packUrl}' (HTTP ${response.status}).`);
-    }
-    Module.copyToFS(options.packName, await response.arrayBuffer());
 
     if (canvas.tabIndex < 0) {
         canvas.tabIndex = 0;
     }
-    release(canvas);
     if (options.resize === 0) {
         observeContainer(canvas);
     }
@@ -95,6 +110,8 @@ export async function prepare(canvas, options) {
 }
 
 export function release(canvas) {
+    preparations.get(canvas)?.abort();
+    preparations.delete(canvas);
     observers.get(canvas)?.disconnect();
     observers.delete(canvas);
 }

--- a/twodog.engine/Engine.cs
+++ b/twodog.engine/Engine.cs
@@ -3,23 +3,44 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 using Godot;
 
 namespace twodog;
 
 /// <summary>Configures and owns an embedded Godot instance.</summary>
-public class Engine : IDisposable
+public class Engine : IDisposable, IAsyncDisposable
 {
+    private enum LifecycleState
+    {
+        Created,
+        Starting,
+        Running,
+        Stopping,
+        Stopped,
+        Disposed
+    }
+
+    private static readonly object ProcessSync = new();
     private static IntPtr _godotInstancePtr = IntPtr.Zero;
+    private static bool _destroyingInstance;
     private readonly string _project;
     private readonly string[] _args;
     private readonly string? _projectPath;
 
     // Only the Engine that started the process-wide instance may destroy it: disposing one whose Start()
     // failed or never ran must not tear down another Engine's instance.
-    private bool _ownsInstance;
-
+    private readonly object _sync = new();
+    private readonly TaskCompletionSource _completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private LifecycleState _state;
+    private IntPtr _ownedInstancePtr;
     private GodotInstance? _godotInstance;
+    private bool _startedLifetime;
+    private bool _disposeRequested;
+    private bool _iterationActive;
+    private bool _runActive;
+    private bool _teardownStarted;
+    private int _ownerThreadId;
 
     /// <summary>Creates an engine and resolves its content when no path is supplied.</summary>
     /// <param name="project">Label passed as Godot's first argument.</param>
@@ -58,7 +79,10 @@ public class Engine : IDisposable
     {
         // A running instance still needs the library; its teardown at process
         // exit is safe because the display server was never destroyed.
-        if (_godotInstancePtr != IntPtr.Zero) return;
+        lock (ProcessSync)
+        {
+            if (_godotInstancePtr != IntPtr.Zero) return;
+        }
 
         // No Godot calls past this point (ProcessExit). Prefer the recorded handle: with hosted multi-instance
         // every sweep must free exactly its own module.
@@ -88,8 +112,15 @@ public class Engine : IDisposable
         }
     }
 
-    public SceneTree Tree => Godot.Engine.Singleton.GetMainLoop() as SceneTree ??
-                             throw new NullReferenceException($"{nameof(Engine)}: Failed to get SceneTree.");
+    public SceneTree Tree
+    {
+        get
+        {
+            EnsureRunning();
+            return Godot.Engine.Singleton.GetMainLoop() as SceneTree ??
+                   throw new NullReferenceException($"{nameof(Engine)}: Failed to get SceneTree.");
+        }
+    }
 
     /// <summary>
     /// Hosted mode: exact libgodot file for this load context, bypassing variant probing. When set, Start() also
@@ -120,49 +151,140 @@ public class Engine : IDisposable
     /// <summary>2dog package version (the engine assembly's version, e.g. 4.7.1.68).</summary>
     public static Version Version { get; } = typeof(Engine).Assembly.GetName().Version ?? new Version(0, 0);
 
+    /// <summary>Completes when this engine reaches a terminal state, after native destruction when it started.</summary>
+    public Task Completion => _completion.Task;
+
+    /// <summary>Raised after this engine's native instance has been destroyed.</summary>
+    public event Action? Exited;
 
     public void Dispose()
     {
-        if (!_ownsInstance || _godotInstancePtr == IntPtr.Zero) return;
-        // On web emscripten owns the loop after Run(); WebHost.ExitCallback destroys the instance, not Dispose().
-        if (OperatingSystem.IsBrowser() && WebHost.MainLoopActive) return;
-        _ownsInstance = false;
-        Destroy();
+        BeginDispose();
+        GC.SuppressFinalize(this);
     }
 
-    public GodotInstance Start()
+    public async ValueTask DisposeAsync()
     {
-        ThrowIfInstanceRunning();
+        BeginDispose();
+        await Completion.ConfigureAwait(false);
+        GC.SuppressFinalize(this);
+    }
 
+    private void BeginDispose()
+    {
+        bool destroy;
+        lock (_sync)
+        {
+            if (_state == LifecycleState.Disposed || _disposeRequested) return;
+            EnsureOwnerThread();
+            _disposeRequested = true;
+            // Game callbacks can dispose their host during Start() or Iteration().
+            // Never free the native engine while its stack is still executing.
+            if (_state == LifecycleState.Starting || _iterationActive || _teardownStarted) return;
+            destroy = _state is LifecycleState.Running or LifecycleState.Stopping;
+            _state = destroy ? LifecycleState.Stopping : LifecycleState.Disposed;
+        }
+
+        if (!destroy)
+        {
+            CompleteExit();
+            return;
+        }
+
+        BeginStartedInstanceDisposal();
+    }
+
+    private void BeginStartedInstanceDisposal()
+    {
         if (OperatingSystem.IsBrowser())
         {
-            // Web has no GodotPlugins.dll on disk: the initializer must be registered up front. One statically
-            // linked instance per page, so no boot lock needed (wasm has no named mutexes anyway).
-            if (!WebHost.HasPluginsInitializer)
-                throw new InvalidOperationException(
-                    $"{nameof(Engine)}: On browser, call {nameof(RegisterWebPluginsInitializer)}() with " +
-                    "the game assembly's plugins-initializer pointer (see TwoDogWebBoot.cs in your web " +
-                    "host folder, from the 2dog template; it must compile into the game project, which " +
-                    "requires the LIBGODOT_ENABLED define) before Start().");
-            return StartCore();
+            try
+            {
+                WebHost.BeginShutdown(DestroyOwnedInstance);
+            }
+            catch
+            {
+                WebHost.ResetMainLoop();
+                DestroyOwnedInstance();
+                throw;
+            }
+            return;
         }
 
-        // Boot mutates process-global state (env vars read during instance creation, CWD via --path). Other load
-        // contexts run their own copy of this class, so serialization must be OS-level.
-        using (ProcessBootLock.Acquire(BootLockTimeout))
+        DestroyOwnedInstance();
+    }
+
+    /// <summary>Starts Godot and returns a borrowed wrapper owned by this Engine.</summary>
+    public GodotInstance Start()
+    {
+        GodotInstance instance;
+        bool disposeAfterStart;
+        lock (_sync)
         {
-            ThrowIfInstanceRunning();
-            ConfigureGodotSharpDir(ProjectAssemblyDir);
-            return StartCore();
+            if (_state != LifecycleState.Created)
+                throw new InvalidOperationException($"{nameof(Engine)}: Start() may only be called once.");
+            _ownerThreadId = System.Environment.CurrentManagedThreadId;
+            _state = LifecycleState.Starting;
+
+            try
+            {
+                if (OperatingSystem.IsBrowser())
+                {
+                    if (!WebHost.HasPluginsInitializer)
+                        throw new InvalidOperationException(
+                            $"{nameof(Engine)}: On browser, call {nameof(RegisterWebPluginsInitializer)}() with " +
+                            "the game assembly's plugins-initializer pointer (see TwoDogWebBoot.cs in your web " +
+                            "host folder, from the 2dog template; it must compile into the game project, which " +
+                            "requires the LIBGODOT_ENABLED define) before Start().");
+                    ThrowIfInstanceRunning();
+                    instance = StartCore();
+                }
+                else
+                {
+                    using (ProcessBootLock.Acquire(BootLockTimeout))
+                    {
+                        ThrowIfInstanceRunning();
+                        ConfigureGodotSharpDir(ProjectAssemblyDir);
+                        instance = StartCore();
+                    }
+                }
+            }
+            catch
+            {
+                if (OperatingSystem.IsBrowser() && _ownedInstancePtr != IntPtr.Zero)
+                {
+                    _state = LifecycleState.Stopping;
+                    WebHost.BeginShutdown(DestroyOwnedInstance);
+                }
+                else
+                {
+                    DestroyOwnedInstance();
+                }
+                throw;
+            }
+
+            disposeAfterStart = _disposeRequested;
+            _state = disposeAfterStart ? LifecycleState.Disposed : LifecycleState.Running;
         }
+
+        if (disposeAfterStart)
+        {
+            BeginStartedInstanceDisposal();
+            throw new ObjectDisposedException(nameof(Engine), "The engine was disposed while Start() was in progress.");
+        }
+
+        return instance;
     }
 
     private void ThrowIfInstanceRunning()
     {
-        if (_godotInstancePtr != IntPtr.Zero)
-            throw new InvalidOperationException(
-                $"{nameof(Engine)}: A Godot instance is already running. Only one instance may exist at a time " +
-                "(a Godot limitation) - dispose the previous Engine before starting a new one.");
+        lock (ProcessSync)
+        {
+            if (_godotInstancePtr != IntPtr.Zero || _destroyingInstance)
+                throw new InvalidOperationException(
+                    $"{nameof(Engine)}: A Godot instance is already running or shutting down. Only one instance " +
+                    "may exist at a time - await the previous Engine.Completion before starting a new one.");
+        }
     }
 
     private GodotInstance StartCore()
@@ -196,33 +318,47 @@ public class Engine : IDisposable
         godotArgs.AddRange(_args);
 
         // Create a Godot instance via P/Invoke (without starting)
-        _godotInstancePtr = CreateGodotInstance(godotArgs.ToArray());
+        var instancePtr = CreateGodotInstance(godotArgs.ToArray());
 
-        if (_godotInstancePtr == IntPtr.Zero)
+        if (instancePtr == IntPtr.Zero)
             throw new NullReferenceException($"{nameof(Engine)}: Error creating Godot instance, returned IntPtr.Zero");
+
+        var instanceConflict = false;
+        lock (ProcessSync)
+        {
+            instanceConflict = _godotInstancePtr != IntPtr.Zero || _destroyingInstance;
+            if (!instanceConflict) _godotInstancePtr = instancePtr;
+        }
+        if (instanceConflict)
+        {
+            LibGodot.libgodot_destroy_godot_instance(instancePtr);
+            throw new InvalidOperationException($"{nameof(Engine)}: A Godot instance is already running or shutting down.");
+        }
+        lock (_sync) _ownedInstancePtr = instancePtr;
 
         Console.WriteLine($"{nameof(Engine)}: Godot instance created successfully!");
 
         // Call start() using our minimal binding
-        if (!LibGodot.CallGodotInstanceStart(_godotInstancePtr))
+        if (!LibGodot.CallGodotInstanceStart(instancePtr))
         {
             Console.Error.WriteLine("Error starting Godot instance");
-            Destroy();
             throw new Exception($"{nameof(Engine)}: Error starting Godot instance");
         }
 
         // Get the GodotInstance object from the native pointer
-        var godotInstance = LibGodot.GetGodotInstanceFromPtr(_godotInstancePtr);
+        var godotInstance = LibGodot.GetGodotInstanceFromPtr(instancePtr);
         if (godotInstance == null)
         {
             Console.Error.WriteLine($"{nameof(Engine)}: Failed to get GodotInstance from pointer");
-            Destroy();
             throw new NullReferenceException($"{nameof(Engine)}: Failed to get GodotInstance from pointer.");
         }
 
         Console.WriteLine($"{nameof(Engine)}: Godot started successfully!");
-        _ownsInstance = true;
-        _godotInstance = godotInstance;
+        lock (_sync)
+        {
+            _godotInstance = godotInstance;
+            _startedLifetime = true;
+        }
         return godotInstance;
     }
 
@@ -272,8 +408,8 @@ public class Engine : IDisposable
     }
 
     /// <summary>
-    /// Browser only: whether Godot quitting also exits the wasm runtime (default true, the standalone web host).
-    /// Hosts that share the runtime with other managed code (Blazor) set false: the instance is still destroyed
+    /// Browser only: whether Godot quitting also exits the wasm runtime (default false).
+    /// Keeping the runtime alive supports sequential restarts: the instance is still destroyed
     /// and <see cref="Exited"/> raised, the page keeps running and a new <see cref="Engine"/> may be started -
     /// on a fresh canvas element (a browser reuses one WebGL context per element).
     /// </summary>
@@ -289,42 +425,214 @@ public class Engine : IDisposable
         }
     }
 
-    /// <summary>Browser only: raised after Godot quit and the instance was destroyed; a new engine may start then.</summary>
-    public event Action? Exited;
-
     /// <summary>
-    /// Runs the main loop. Desktop: blocks until quit, caller still disposes. Browser: hands the loop to
-    /// emscripten and returns immediately; the engine destroys itself on quit - do not Dispose() afterwards.
+    /// Runs the main loop. Desktop: blocks until quit; dispose afterward. Browser: hands the loop to
+    /// emscripten and returns immediately; async teardown destroys the instance on quit.
     /// </summary>
-    /// <param name="perFrame">Optional callback invoked once per frame before the engine iteration.</param>
+    /// <param name="perFrame">Optional callback invoked once per frame after the engine iteration.</param>
     public void Run(Action? perFrame = null)
     {
-        if (_godotInstance == null || _godotInstancePtr == IntPtr.Zero)
-            throw new InvalidOperationException($"{nameof(Engine)}: Start() must succeed before Run().");
+        EnsureRunning();
+        if (_runActive || _iterationActive)
+            throw new InvalidOperationException($"{nameof(Engine)}: The main loop is already running.");
+        _runActive = true;
 
         if (OperatingSystem.IsBrowser())
         {
-            WebHost.RunMainLoop(perFrame, () =>
+            try
             {
-                _ownsInstance = false;
-                Destroy();
-                _godotInstance = null;
-                Exited?.Invoke();
-            });
+                WebHost.RunMainLoop(IterateCore, perFrame, DestroyOwnedInstance);
+            }
+            catch
+            {
+                _runActive = false;
+                throw;
+            }
             return;
         }
 
-        while (!_godotInstance.Iteration())
+        try
         {
-            perFrame?.Invoke();
+            while (!_disposeRequested && !IterateCore())
+                perFrame?.Invoke();
+        }
+        finally
+        {
+            _runActive = false;
         }
     }
 
-    private static void Destroy()
+    /// <summary>Runs one engine frame. A true result means Godot requested exit; dispose this Engine afterward.</summary>
+    public bool Iteration()
     {
-        LibGodot.libgodot_destroy_godot_instance(_godotInstancePtr);
-        Console.WriteLine($"{nameof(Engine)}: Godot instance destroyed.");
-        _godotInstancePtr = IntPtr.Zero;
+        if (_runActive)
+            throw new InvalidOperationException($"{nameof(Engine)}: Run() already owns the frame loop.");
+        return IterateCore();
+    }
+
+    private bool IterateCore()
+    {
+        GodotInstance instance;
+        lock (_sync)
+        {
+            EnsureActiveStateLocked();
+            if (_iterationActive)
+                throw new InvalidOperationException($"{nameof(Engine)}: Iteration() cannot be called from an engine frame.");
+            instance = _godotInstance!;
+        }
+        EnsureOwnedInstance();
+
+        _iterationActive = true;
+        try
+        {
+            var quit = OperatingSystem.IsBrowser() ? WebHost.Iteration() : instance.Iteration();
+            return quit || _disposeRequested;
+        }
+        finally
+        {
+            _iterationActive = false;
+            if (_disposeRequested)
+                BeginStartedInstanceDisposal();
+        }
+    }
+
+    /// <summary>Requests a graceful quit. Repeated requests are harmless.</summary>
+    public void RequestQuit()
+    {
+        lock (_sync)
+        {
+            if (_state is LifecycleState.Stopping or LifecycleState.Stopped or LifecycleState.Disposed) return;
+            EnsureActiveStateLocked();
+            _state = LifecycleState.Stopping;
+        }
+
+        try
+        {
+            RequestQuitCore();
+        }
+        catch
+        {
+            lock (_sync)
+            {
+                if (_state == LifecycleState.Stopping) _state = LifecycleState.Running;
+            }
+            throw;
+        }
+    }
+
+    private void RequestQuitCore() => TreeForOwnedInstance().Quit();
+
+    private SceneTree TreeForOwnedInstance()
+    {
+        IntPtr owned;
+        lock (_sync)
+            owned = _ownedInstancePtr;
+        if (owned == IntPtr.Zero || owned != GetCurrentInstancePtr())
+            throw new InvalidOperationException($"{nameof(Engine)}: This engine no longer owns the running instance.");
+        return Godot.Engine.Singleton.GetMainLoop() as SceneTree ??
+               throw new NullReferenceException($"{nameof(Engine)}: Failed to get SceneTree.");
+    }
+
+    private void EnsureRunning()
+    {
+        lock (_sync) EnsureActiveStateLocked();
+        EnsureOwnedInstance();
+    }
+
+    private void EnsureActiveStateLocked()
+    {
+        EnsureOwnerThread();
+        if (_state is not (LifecycleState.Running or LifecycleState.Stopping) ||
+            _ownedInstancePtr == IntPtr.Zero || _godotInstance is null)
+            throw new InvalidOperationException(
+                $"{nameof(Engine)}: Start() must succeed and this engine must own the active instance.");
+    }
+
+    private void EnsureOwnerThread()
+    {
+        if (_ownerThreadId != 0 && !Completion.IsCompleted &&
+            _ownerThreadId != System.Environment.CurrentManagedThreadId)
+            throw new InvalidOperationException($"{nameof(Engine)}: Lifecycle calls must run on the thread that called Start().");
+    }
+
+    private void EnsureOwnedInstance()
+    {
+        IntPtr owned;
+        lock (_sync) owned = _ownedInstancePtr;
+        if (owned == IntPtr.Zero || owned != GetCurrentInstancePtr())
+            throw new InvalidOperationException($"{nameof(Engine)}: This engine no longer owns the active instance.");
+    }
+
+    private static IntPtr GetCurrentInstancePtr()
+    {
+        lock (ProcessSync) return _godotInstancePtr;
+    }
+
+    private void DestroyOwnedInstance()
+    {
+        IntPtr instancePtr;
+        lock (_sync)
+        {
+            if (_teardownStarted) return;
+            _teardownStarted = true;
+            instancePtr = _ownedInstancePtr;
+            _ownedInstancePtr = IntPtr.Zero;
+            _godotInstance = null;
+            _state = _disposeRequested ? LifecycleState.Disposed : LifecycleState.Stopped;
+        }
+
+        var destroy = false;
+        if (instancePtr != IntPtr.Zero)
+        {
+            lock (ProcessSync)
+            {
+                if (_godotInstancePtr == instancePtr)
+                {
+                    _destroyingInstance = true;
+                    destroy = true;
+                }
+            }
+        }
+
+        if (destroy)
+        {
+            try
+            {
+                LibGodot.libgodot_destroy_godot_instance(instancePtr);
+                Console.WriteLine($"{nameof(Engine)}: Godot instance destroyed.");
+            }
+            catch (Exception e)
+            {
+                _completion.TrySetException(e);
+                throw;
+            }
+            finally
+            {
+                lock (ProcessSync)
+                {
+                    if (_godotInstancePtr == instancePtr) _godotInstancePtr = IntPtr.Zero;
+                    _destroyingInstance = false;
+                }
+            }
+        }
+        CompleteExit();
+    }
+
+    private void CompleteExit()
+    {
+        if (!_completion.TrySetResult()) return;
+        if (!_startedLifetime || Exited is not { } exited) return;
+        foreach (Action handler in exited.GetInvocationList())
+        {
+            try
+            {
+                handler();
+            }
+            catch (Exception e)
+            {
+                Console.Error.WriteLine($"{nameof(Engine)}: {nameof(Exited)} handler failed: {e}");
+            }
+        }
     }
 
     /// <summary>

--- a/twodog.engine/Engine.cs
+++ b/twodog.engine/Engine.cs
@@ -40,6 +40,7 @@ public class Engine : IDisposable, IAsyncDisposable
     private bool _iterationActive;
     private bool _runActive;
     private bool _teardownStarted;
+    private bool _exitNotified;
     private int _ownerThreadId;
 
     /// <summary>Creates an engine and resolves its content when no path is supplied.</summary>
@@ -151,7 +152,7 @@ public class Engine : IDisposable, IAsyncDisposable
     /// <summary>2dog package version (the engine assembly's version, e.g. 4.7.1.68).</summary>
     public static Version Version { get; } = typeof(Engine).Assembly.GetName().Version ?? new Version(0, 0);
 
-    /// <summary>Completes when this engine reaches a terminal state, after native destruction when it started.</summary>
+    /// <summary>Completes after native destruction and synchronous Exited handlers when this engine started.</summary>
     public Task Completion => _completion.Task;
 
     /// <summary>Raised after this engine's native instance has been destroyed.</summary>
@@ -254,7 +255,7 @@ public class Engine : IDisposable, IAsyncDisposable
                 if (OperatingSystem.IsBrowser() && _ownedInstancePtr != IntPtr.Zero)
                 {
                     _state = LifecycleState.Stopping;
-                    WebHost.BeginShutdown(DestroyOwnedInstance);
+                    BeginStartedInstanceDisposal();
                 }
                 else
                 {
@@ -620,18 +621,29 @@ public class Engine : IDisposable, IAsyncDisposable
 
     private void CompleteExit()
     {
-        if (!_completion.TrySetResult()) return;
-        if (!_startedLifetime || Exited is not { } exited) return;
-        foreach (Action handler in exited.GetInvocationList())
+        lock (_sync)
         {
-            try
+            if (_exitNotified || _completion.Task.IsCompleted) return;
+            _exitNotified = true;
+        }
+        try
+        {
+            if (!_startedLifetime || Exited is not { } exited) return;
+            foreach (Action handler in exited.GetInvocationList())
             {
-                handler();
+                try
+                {
+                    handler();
+                }
+                catch (Exception e)
+                {
+                    Console.Error.WriteLine($"{nameof(Engine)}: {nameof(Exited)} handler failed: {e}");
+                }
             }
-            catch (Exception e)
-            {
-                Console.Error.WriteLine($"{nameof(Engine)}: {nameof(Exited)} handler failed: {e}");
-            }
+        }
+        finally
+        {
+            _completion.TrySetResult();
         }
     }
 

--- a/twodog.engine/Engine.cs
+++ b/twodog.engine/Engine.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Threading;
 using System.Threading.Tasks;
 using Godot;
 
@@ -42,6 +43,7 @@ public class Engine : IDisposable, IAsyncDisposable
     private bool _teardownStarted;
     private bool _exitNotified;
     private int _ownerThreadId;
+    private SynchronizationContext? _hostSynchronizationContext;
 
     /// <summary>Creates an engine and resolves its content when no path is supplied.</summary>
     /// <param name="project">Label passed as Godot's first argument.</param>
@@ -225,6 +227,7 @@ public class Engine : IDisposable, IAsyncDisposable
             if (_state != LifecycleState.Created)
                 throw new InvalidOperationException($"{nameof(Engine)}: Start() may only be called once.");
             _ownerThreadId = System.Environment.CurrentManagedThreadId;
+            _hostSynchronizationContext = SynchronizationContext.Current;
             _state = LifecycleState.Starting;
 
             try
@@ -604,6 +607,7 @@ public class Engine : IDisposable, IAsyncDisposable
             }
             catch (Exception e)
             {
+                RestoreHostSynchronizationContext();
                 _completion.TrySetException(e);
                 throw;
             }
@@ -626,6 +630,7 @@ public class Engine : IDisposable, IAsyncDisposable
             if (_exitNotified || _completion.Task.IsCompleted) return;
             _exitNotified = true;
         }
+        RestoreHostSynchronizationContext();
         try
         {
             if (!_startedLifetime || Exited is not { } exited) return;
@@ -645,6 +650,15 @@ public class Engine : IDisposable, IAsyncDisposable
         {
             _completion.TrySetResult();
         }
+    }
+
+    private void RestoreHostSynchronizationContext()
+    {
+        // Godot installs a context backed by its frame loop. Once that loop is gone,
+        // host awaits and exit callbacks must not keep posting to its abandoned queue.
+        if (_ownerThreadId == System.Environment.CurrentManagedThreadId &&
+            SynchronizationContext.Current is GodotSynchronizationContext)
+            SynchronizationContext.SetSynchronizationContext(_hostSynchronizationContext);
     }
 
     /// <summary>

--- a/twodog.engine/README.md
+++ b/twodog.engine/README.md
@@ -16,13 +16,20 @@ dnx 2dog add
 using twodog;
 
 using var engine = new Engine("MyGodotApp", args: args);
-using var godot = engine.Start();
+engine.Start();
 
-while (!godot.Iteration())
+while (!engine.Iteration())
 {
     // Your code runs here every frame.
 }
 ```
+
+`Engine` owns the instance; `Start()` returns a borrowed `GodotInstance`
+compatibility handle. Use `RequestQuit()`, `Completion`, and `Exited` for
+lifecycle control. Desktop disposal is synchronous; browser code awaits
+`DisposeAsync()`. After completion, create a new `Engine` to restart.
+Pump and access Godot from the thread that called `Start()`; do not iterate and
+dispose the same engine concurrently from different threads.
 
 The generated host embeds its `GodotProjectDir`. The constructor uses that
 source directory during development and the adjacent `.pck` after publish.

--- a/twodog.engine/TestingFixtureBase.cs
+++ b/twodog.engine/TestingFixtureBase.cs
@@ -51,13 +51,12 @@ public abstract class FixtureBase : IDisposable
     /// <summary>The active scene tree.</summary>
     public SceneTree Tree => Engine.Tree;
 
-    /// <summary>Disposes the Godot instance and its owning engine.</summary>
+    /// <summary>Disposes the owning engine.</summary>
     public void Dispose()
     {
         GC.SuppressFinalize(this);
 
         Console.WriteLine("Shutting down Godot...");
-        GodotInstance.Dispose();
         Engine.Dispose();
         Console.WriteLine("Godot shut down successfully.");
     }

--- a/twodog.engine/WebHost.cs
+++ b/twodog.engine/WebHost.cs
@@ -123,7 +123,8 @@ internal static unsafe partial class WebHost
         }
         catch
         {
-            ResetMainLoop();
+            // Iteration can request disposal before throwing. Keep its exit poller alive.
+            if (!_shutdownStarted) ResetMainLoop();
             throw;
         }
     }

--- a/twodog.engine/WebHost.cs
+++ b/twodog.engine/WebHost.cs
@@ -15,19 +15,21 @@ namespace twodog;
 internal static unsafe partial class WebHost
 {
     private static nint _pluginsInitializer;
-    private static int _bootCount;
+    private static bool _pluginsInitialized;
+    private static Func<bool>? _iterate;
     private static Action? _perFrame;
     private static Action? _onShutdown;
     private static bool _shutdownComplete;
+    private static bool _shutdownStarted;
 
-    /// <summary>True while emscripten owns the main loop; Engine.Dispose() is a no-op then.</summary>
+    /// <summary>True while emscripten owns the frame loop or asynchronous shutdown.</summary>
     internal static bool MainLoopActive { get; private set; }
 
     /// <summary>
     /// Whether quitting Godot also exits the wasm runtime (the standalone web host). Hosts sharing the runtime
     /// with other managed code (Blazor) keep it alive; the instance is still destroyed.
     /// </summary>
-    internal static bool ExitRuntimeOnQuit { get; set; } = true;
+    internal static bool ExitRuntimeOnQuit { get; set; }
 
     // Exported by the mono module (GD_MONO_LIBGODOT_ENABLED); GDMono init calls the registered callback for the
     // godot_plugins_initialize pointer instead of loading GodotPlugins.dll.
@@ -38,6 +40,8 @@ internal static unsafe partial class WebHost
     // (redraw/max_fps handling + main_loop_iterate), returns non-zero on quit.
     [LibraryImport("libgodot")]
     private static partial byte libgodot_web_iteration();
+
+    internal static bool Iteration() => libgodot_web_iteration() != 0;
 
     // Emscripten runtime functions, resolved statically against the main
     // module by the wasm pinvoke table ("*" convention).
@@ -57,32 +61,22 @@ internal static unsafe partial class WebHost
 
     [UnmanagedCallersOnly]
     private static nint LoadFromExecutable() =>
-        (nint)(delegate* unmanaged<nint, nint, nint, int, godot_bool>)&InitializeFromGameProject;
+        (nint)(delegate* unmanaged<nint, nint, nint, int, godot_bool>)&InitializePlugins;
 
-    /// <summary>
-    /// GDMono's plugins initializer for every engine lifetime. The game's source-generated initializer runs once
-    /// (its DllImportResolver registration cannot repeat); later lifetimes redo what it does per engine - reset the
-    /// script bridge (which replays the script lookups), refresh the native callbacks, export the managed ones.
-    /// </summary>
     [UnmanagedCallersOnly]
-    private static godot_bool InitializeFromGameProject(nint godotDllHandle, nint outManagedCallbacks,
+    private static godot_bool InitializePlugins(nint godotDllHandle, nint outManagedCallbacks,
         nint unmanagedCallbacks, int unmanagedCallbacksSize)
     {
         try
         {
-            if (_bootCount == 0)
-            {
-                var initialize = (delegate* unmanaged<nint, nint, nint, int, godot_bool>)_pluginsInitializer;
-                var ok = initialize(godotDllHandle, outManagedCallbacks, unmanagedCallbacks, unmanagedCallbacksSize);
-                if (ok.ToBool())
-                    _bootCount++;
-                return ok;
-            }
-
-            ScriptManagerBridge.ResetForEngineReinitialization();
-            NativeFuncs.Initialize(unmanagedCallbacks, unmanagedCallbacksSize);
-            ManagedCallbacks.Create(outManagedCallbacks);
-            _bootCount++;
+            var initialize = (delegate* unmanaged<nint, nint, nint, int, godot_bool>)_pluginsInitializer;
+            var ok = initialize(godotDllHandle, outManagedCallbacks, unmanagedCallbacks, unmanagedCallbacksSize);
+            if (!ok.ToBool()) return ok;
+            // The game may compile against stock GodotSharp and run against the fork.
+            // Keep the fork-only reset here, after the initializer refreshes native callbacks,
+            // matching GodotPlugins on desktop without duplicating the generated initializer.
+            if (_pluginsInitialized) ScriptManagerBridge.ResetForEngineReinitialization();
+            _pluginsInitialized = true;
             return godot_bool.True;
         }
         catch (Exception e)
@@ -110,26 +104,72 @@ internal static unsafe partial class WebHost
     /// Hands the main loop to emscripten and returns immediately; on quit the async teardown runs and
     /// <paramref name="onShutdown"/> destroys the instance.
     /// </summary>
-    internal static void RunMainLoop(Action? perFrame, Action onShutdown)
+    internal static void RunMainLoop(Func<bool> iterate, Action? perFrame, Action onShutdown)
     {
         if (MainLoopActive)
             throw new InvalidOperationException($"{nameof(WebHost)}: main loop is already running.");
+        _iterate = iterate;
         _perFrame = perFrame;
         _onShutdown = onShutdown;
         MainLoopActive = true;
 
-        emscripten_set_main_loop((nint)(delegate* unmanaged<void>)&MainLoopCallback, -1, 0);
+        try
+        {
+            emscripten_set_main_loop((nint)(delegate* unmanaged<void>)&MainLoopCallback, -1, 0);
 
-        // Run the first frame immediately (mirrors the reference host in
-        // Godot's LibGodotMain.cs); the engine may already request quit here.
-        RunFrame();
+            // Run the first frame immediately (mirrors the reference host in
+            // Godot's LibGodotMain.cs); the engine may already request quit here.
+            RunFrame();
+        }
+        catch
+        {
+            ResetMainLoop();
+            throw;
+        }
+    }
+
+    /// <summary>Stops the frame loop, if present, and begins the shared asynchronous teardown.</summary>
+    internal static void BeginShutdown(Action onShutdown)
+    {
+        if (_shutdownStarted) return;
+        _onShutdown = onShutdown;
+        MainLoopActive = true;
+        try
+        {
+            SetupExit();
+        }
+        catch
+        {
+            ResetMainLoop();
+            throw;
+        }
+    }
+
+    internal static void ResetMainLoop()
+    {
+        if (MainLoopActive) emscripten_cancel_main_loop();
+        MainLoopActive = false;
+        _shutdownComplete = false;
+        _shutdownStarted = false;
+        _iterate = null;
+        _perFrame = null;
+        _onShutdown = null;
     }
 
     [UnmanagedCallersOnly]
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static void MainLoopCallback()
     {
-        RunFrame();
+        try
+        {
+            RunFrame();
+        }
+        catch (Exception e)
+        {
+            // Never unwind managed exceptions through Emscripten's native frame callback.
+            Console.Error.WriteLine(e);
+            SetupExit();
+        }
     }
 
     /// <summary>
@@ -138,7 +178,7 @@ internal static unsafe partial class WebHost
     /// </summary>
     private static void RunFrame()
     {
-        if (libgodot_web_iteration() != 0)
+        if (_iterate!())
         {
             SetupExit();
             return;
@@ -161,6 +201,8 @@ internal static unsafe partial class WebHost
 
     private static void SetupExit()
     {
+        if (_shutdownStarted) return;
+        _shutdownStarted = true;
         // Swap the frame callback for the exit poller and start Godot's async teardown (IDBFS flush etc.); the
         // poller destroys the instance once it completes.
         emscripten_cancel_main_loop();
@@ -184,18 +226,24 @@ internal static unsafe partial class WebHost
             return; // Still waiting for async teardown.
         }
 
+        var onShutdown = _onShutdown;
+        var exitRuntime = ExitRuntimeOnQuit;
+        emscripten_cancel_main_loop();
         MainLoopActive = false;
         _shutdownComplete = false;
+        _shutdownStarted = false;
+        _iterate = null;
+        _perFrame = null;
+        _onShutdown = null;
         try
         {
-            _onShutdown?.Invoke();
+            onShutdown?.Invoke();
         }
         catch (Exception e)
         {
             Console.Error.WriteLine(e);
         }
-        emscripten_cancel_main_loop();
-        if (ExitRuntimeOnQuit)
+        if (exitRuntime)
             emscripten_force_exit(0);
     }
 }

--- a/twodog.hosting.runtime/ResidentProgram.cs
+++ b/twodog.hosting.runtime/ResidentProgram.cs
@@ -23,29 +23,23 @@ public sealed class ResidentProgram : IEngineProgram
         {
             // Disposed while waiting to boot: never bring up an engine nobody observes.
             if (ctx.QuitRequested) return 0;
-            var engine = new Engine(ctx.Tag, ctx.ProjectDir, ctx.Args)
+            using var engine = new Engine(ctx.Tag, ctx.ProjectDir, ctx.Args)
             {
                 NativePath = ctx.NativePath,
                 ProjectAssemblyDir = ctx.ProgramAssemblyDir,
             };
-            using var godot = engine.Start();
+            var godot = engine.Start();
             var session = new EngineSession(engine, godot);
             ctx.SignalBooted();
-            try
+            while (true)
             {
-                while (!ctx.QuitRequested)
-                {
-                    if (godot.Iteration()) break;
-                    // Bounded batch: an always-nonempty queue must not starve
-                    // frame pumping or the QuitRequested check.
-                    var batch = 8;
-                    while (batch-- > 0 && !ctx.QuitRequested && queue.TryTake(out var item))
-                        Execute(session, item);
-                }
-            }
-            finally
-            {
-                engine.Dispose();
+                if (ctx.QuitRequested) engine.RequestQuit();
+                if (engine.Iteration()) break;
+                // Bounded batch: an always-nonempty queue must not starve
+                // frame pumping or the QuitRequested check.
+                var batch = 8;
+                while (batch-- > 0 && !ctx.QuitRequested && queue.TryTake(out var item))
+                    Execute(session, item);
             }
         }
         finally

--- a/twodog.hosting.runtime/Scenarios.cs
+++ b/twodog.hosting.runtime/Scenarios.cs
@@ -27,7 +27,7 @@ public sealed class EngineSession(Engine engine, GodotInstance godot)
     {
         for (var i = 0; i < count; i++)
         {
-            if (Godot.Iteration()) break;
+            if (Engine.Iteration()) break;
         }
     }
 }

--- a/twodog.tests/Avalonia/InputInjectionTests.cs
+++ b/twodog.tests/Avalonia/InputInjectionTests.cs
@@ -17,11 +17,11 @@ public class InputInjectionTests(HeadlessFixture godot)
     public void KeyPress_IsObservable_AfterFlush()
     {
         Inject(new InputEventKey { Keycode = Key.F13, PhysicalKeycode = Key.F13, Pressed = true });
-        godot.GodotInstance.Iteration();
+        godot.Engine.Iteration();
         Assert.True(Input.IsKeyPressed(Key.F13));
 
         Inject(new InputEventKey { Keycode = Key.F13, PhysicalKeycode = Key.F13, Pressed = false });
-        godot.GodotInstance.Iteration();
+        godot.Engine.Iteration();
         Assert.False(Input.IsKeyPressed(Key.F13));
     }
 
@@ -34,7 +34,7 @@ public class InputInjectionTests(HeadlessFixture godot)
             ButtonIndex = MouseButton.Left, Pressed = true,
             Position = pos, GlobalPosition = pos, ButtonMask = MouseButtonMask.Left,
         });
-        godot.GodotInstance.Iteration();
+        godot.Engine.Iteration();
         Assert.True(Input.IsMouseButtonPressed(MouseButton.Left));
 
         Inject(new InputEventMouseButton
@@ -42,7 +42,7 @@ public class InputInjectionTests(HeadlessFixture godot)
             ButtonIndex = MouseButton.Left, Pressed = false,
             Position = pos, GlobalPosition = pos,
         });
-        godot.GodotInstance.Iteration();
+        godot.Engine.Iteration();
         Assert.False(Input.IsMouseButtonPressed(MouseButton.Left));
     }
 
@@ -80,7 +80,7 @@ public class InputInjectionTests(HeadlessFixture godot)
                         Relative = new Vector2(1, 0), ButtonMask = 0,
                     });
                 }
-                godot.GodotInstance.Iteration();
+                godot.Engine.Iteration();
             }
         }
         finally

--- a/twodog.tests/Engine/BootCwdIndependenceTests.cs
+++ b/twodog.tests/Engine/BootCwdIndependenceTests.cs
@@ -56,7 +56,7 @@ public class BootCwdIndependenceTests
             for (var i = 0; i < 3; i++)
             {
                 using var engine = new Engine($"cwd-independence-{i}", projectDir, "--headless");
-                using var godot = engine.Start();
+                engine.Start();
                 var name = (string)ProjectSettings.GetSetting("application/config/name");
                 Assert.Equal("showcase", name);
             }

--- a/twodog.tests/Engine/EngineRestartTests.cs
+++ b/twodog.tests/Engine/EngineRestartTests.cs
@@ -216,7 +216,9 @@ public class EngineRestartTests
         var projectDir = Engine.ResolveProjectDir();
         AssemblyPreloader.PreloadGameAssemblies(projectDir);
 
-        using (var failed = new Engine("failed-setup", projectDir, "--rendering-driver"))
+        // Keep AppKit out of worker-thread tests, including failed startup.
+        // The malformed option must remain last so its argument is still missing.
+        using (var failed = new Engine("failed-setup", projectDir, "--headless", "--rendering-driver"))
             Assert.ThrowsAny<Exception>(() => failed.Start());
 
         using var recovered = new Engine("after-failed-setup", projectDir, "--headless");
@@ -230,8 +232,9 @@ public class EngineRestartTests
         var projectDir = Engine.ResolveProjectDir();
         AssemblyPreloader.PreloadGameAssemblies(projectDir);
 
+        // Select the headless macOS OS before setup validates the invalid driver.
         using (var failed = new Engine(
-                   "failed-second-phase", projectDir, "--display-driver", "definitely-missing"))
+                   "failed-second-phase", projectDir, "--headless", "--display-driver", "definitely-missing"))
             Assert.ThrowsAny<Exception>(() => failed.Start());
 
         using var recovered = new Engine("after-failed-second-phase", projectDir, "--headless");

--- a/twodog.tests/Engine/EngineRestartTests.cs
+++ b/twodog.tests/Engine/EngineRestartTests.cs
@@ -121,20 +121,25 @@ public class EngineRestartTests
         var projectDir = Engine.ResolveProjectDir();
         AssemblyPreloader.PreloadGameAssemblies(projectDir);
         using var engine = new Engine("exit-order", projectDir, "--headless");
+        var hostContext = SynchronizationContext.Current;
         engine.Start();
         var notifications = 0;
         var completedInsideHandler = false;
+        SynchronizationContext? exitContext = null;
         Task? reentrantDisposal = null;
         engine.Exited += () =>
         {
             notifications++;
             completedInsideHandler = engine.Completion.IsCompleted;
+            exitContext = SynchronizationContext.Current;
             reentrantDisposal = engine.DisposeAsync().AsTask();
         };
         engine.Exited += () => notifications++;
 
         engine.Dispose();
 
+        Assert.Same(hostContext, SynchronizationContext.Current);
+        Assert.Same(hostContext, exitContext);
         Assert.False(completedInsideHandler);
         Assert.Equal(2, notifications);
         Assert.True(engine.Completion.IsCompletedSuccessfully);

--- a/twodog.tests/Engine/EngineRestartTests.cs
+++ b/twodog.tests/Engine/EngineRestartTests.cs
@@ -116,6 +116,33 @@ public class EngineRestartTests
     }
 
     [Fact]
+    public async Task Completion_FollowsExitedHandlers_AndReentrantDisposalNotifiesOnce()
+    {
+        var projectDir = Engine.ResolveProjectDir();
+        AssemblyPreloader.PreloadGameAssemblies(projectDir);
+        using var engine = new Engine("exit-order", projectDir, "--headless");
+        engine.Start();
+        var notifications = 0;
+        var completedInsideHandler = false;
+        Task? reentrantDisposal = null;
+        engine.Exited += () =>
+        {
+            notifications++;
+            completedInsideHandler = engine.Completion.IsCompleted;
+            reentrantDisposal = engine.DisposeAsync().AsTask();
+        };
+        engine.Exited += () => notifications++;
+
+        engine.Dispose();
+
+        Assert.False(completedInsideHandler);
+        Assert.Equal(2, notifications);
+        Assert.True(engine.Completion.IsCompletedSuccessfully);
+        Assert.NotNull(reentrantDisposal);
+        await reentrantDisposal.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
     public async Task Dispose_WithoutStartCompletesWithoutExited()
     {
         var engine = new Engine("never-started", Engine.ResolveProjectDir(), "--headless");

--- a/twodog.tests/Engine/EngineRestartTests.cs
+++ b/twodog.tests/Engine/EngineRestartTests.cs
@@ -26,28 +26,200 @@ public class EngineRestartTests
         AssemblyPreloader.PreloadGameAssemblies(projectDir);
 
         var engine = new Engine("restart-direct", projectDir, "--headless");
-        var godot = engine.Start();
+        engine.Start();
         try
         {
-            Assert.False(godot.Iteration());
+            Assert.False(engine.Iteration());
 
             // Only one instance may run at a time. Disposing the failed
             // Engine must not affect the running instance.
             using var concurrent = new Engine("restart-concurrent", projectDir, "--headless");
             Assert.Throws<InvalidOperationException>(() => concurrent.Start());
 
-            Assert.False(godot.Iteration());
+            Assert.False(engine.Iteration());
         }
         finally
         {
-            godot.Dispose();
             engine.Dispose();
         }
 
         // Sequential restart: after disposing, a new engine can be started
         // in the same process.
         using var engine2 = new Engine("restart-direct-2", projectDir, "--headless");
-        using var godot2 = engine2.Start();
-        Assert.False(godot2.Iteration());
+        engine2.Start();
+        Assert.False(engine2.Iteration());
+    }
+
+    [Fact]
+    public async Task Quit_DestroysCompletesAndAllowsRestart()
+    {
+        var projectDir = Engine.ResolveProjectDir();
+        AssemblyPreloader.PreloadGameAssemblies(projectDir);
+
+        using var engine = new Engine("managed-lifecycle", projectDir, "--headless");
+        engine.Start();
+        var exited = 0;
+        engine.Exited += () => exited++;
+
+        engine.RequestQuit();
+        engine.RequestQuit();
+        Assert.True(engine.Iteration());
+        Assert.False(engine.Completion.IsCompleted);
+        engine.Dispose();
+        await engine.Completion;
+        Assert.Equal(1, exited);
+        Assert.Throws<InvalidOperationException>(() => engine.Iteration());
+        Assert.Throws<InvalidOperationException>(() => engine.Start());
+
+        using var restarted = new Engine("managed-lifecycle-2", projectDir, "--headless");
+        restarted.Start();
+        Assert.False(restarted.Iteration());
+    }
+
+    [Fact]
+    public void LifecycleStateGuardsRejectInvalidUseAndStaleEngine()
+    {
+        var projectDir = Engine.ResolveProjectDir();
+        AssemblyPreloader.PreloadGameAssemblies(projectDir);
+
+        using var unstarted = new Engine("unstarted", projectDir, "--headless");
+        Assert.Throws<InvalidOperationException>(() => unstarted.Iteration());
+        Assert.Throws<InvalidOperationException>(() => unstarted.RequestQuit());
+
+        var stale = new Engine("stale", projectDir, "--headless");
+        stale.Start();
+        stale.Dispose();
+
+        using var current = new Engine("current", projectDir, "--headless");
+        current.Start();
+        Assert.Throws<InvalidOperationException>(() => stale.Iteration());
+        Assert.Throws<InvalidOperationException>(() => stale.Start());
+        Assert.False(current.Iteration());
+    }
+
+    [Fact]
+    public async Task Dispose_ContainsExitedHandlerFailuresAndNotifiesEveryHandler()
+    {
+        var projectDir = Engine.ResolveProjectDir();
+        AssemblyPreloader.PreloadGameAssemblies(projectDir);
+
+        var engine = new Engine("exit-handlers", projectDir, "--headless");
+        engine.Start();
+        var notified = false;
+        engine.Exited += () => throw new InvalidOperationException("expected handler failure");
+        engine.Exited += () => notified = true;
+
+        engine.Dispose();
+
+        await engine.Completion;
+        Assert.True(notified);
+    }
+
+    [Fact]
+    public async Task Dispose_WithoutStartCompletesWithoutExited()
+    {
+        var engine = new Engine("never-started", Engine.ResolveProjectDir(), "--headless");
+        var exited = false;
+        engine.Exited += () => exited = true;
+
+        engine.Dispose();
+
+        await engine.Completion;
+        Assert.False(exited);
+    }
+
+    [Fact]
+    public void CommandLineQuitStateDoesNotLeakIntoRestart()
+    {
+        var projectDir = Engine.ResolveProjectDir();
+        AssemblyPreloader.PreloadGameAssemblies(projectDir);
+
+        using (var first = new Engine("quit-after", projectDir, "--headless", "--quit-after", "1"))
+        {
+            first.Start();
+            Assert.True(first.Iteration());
+        }
+
+        using var second = new Engine("after-quit-after", projectDir, "--headless");
+        second.Start();
+        Assert.False(second.Iteration());
+    }
+
+    [Fact]
+    public void OutputSettingsDoNotLeakIntoRestart()
+    {
+        var projectDir = Engine.ResolveProjectDir();
+        AssemblyPreloader.PreloadGameAssemblies(projectDir);
+
+        using (var first = new Engine("quiet-lifetime", projectDir, "--headless", "--quiet"))
+        {
+            first.Start();
+            Assert.False(Godot.Engine.PrintToStdOut);
+            Godot.Engine.PrintErrorMessages = false;
+        }
+
+        using var second = new Engine("normal-output-lifetime", projectDir, "--headless");
+        second.Start();
+        Assert.True(Godot.Engine.PrintToStdOut);
+        Assert.True(Godot.Engine.PrintErrorMessages);
+        Assert.False(second.Iteration());
+    }
+
+    [Fact]
+    public void NativeInstanceRejectsSecondStartWithoutBreakingLifetime()
+    {
+        var projectDir = Engine.ResolveProjectDir();
+        AssemblyPreloader.PreloadGameAssemblies(projectDir);
+
+        using var engine = new Engine("double-native-start", projectDir, "--headless");
+        var instance = engine.Start();
+
+        Assert.False(instance.Start());
+        Assert.False(engine.Iteration());
+    }
+
+    [Fact]
+    public void FailedSetupDoesNotPoisonNextLifetime()
+    {
+        var projectDir = Engine.ResolveProjectDir();
+        AssemblyPreloader.PreloadGameAssemblies(projectDir);
+
+        using (var failed = new Engine("failed-setup", projectDir, "--rendering-driver"))
+            Assert.ThrowsAny<Exception>(() => failed.Start());
+
+        using var recovered = new Engine("after-failed-setup", projectDir, "--headless");
+        recovered.Start();
+        Assert.False(recovered.Iteration());
+    }
+
+    [Fact]
+    public void InvalidDisplayDriverDoesNotPoisonNextLifetime()
+    {
+        var projectDir = Engine.ResolveProjectDir();
+        AssemblyPreloader.PreloadGameAssemblies(projectDir);
+
+        using (var failed = new Engine(
+                   "failed-second-phase", projectDir, "--display-driver", "definitely-missing"))
+            Assert.ThrowsAny<Exception>(() => failed.Start());
+
+        using var recovered = new Engine("after-failed-second-phase", projectDir, "--headless");
+        recovered.Start();
+        Assert.False(recovered.Iteration());
+    }
+
+    [Fact]
+    public void FailedMainLoopStartDoesNotPoisonNextLifetime()
+    {
+        var projectDir = Engine.ResolveProjectDir();
+        AssemblyPreloader.PreloadGameAssemblies(projectDir);
+
+        // Node exists, but is not a MainLoop. This reaches Main::start() after
+        // both setup phases, without invoking a platform error dialog.
+        using (var failed = new Engine("failed-main-loop", projectDir, "--headless", "--main-loop", "Node"))
+            Assert.ThrowsAny<Exception>(() => failed.Start());
+
+        using var recovered = new Engine("after-failed-main-loop", projectDir, "--headless");
+        recovered.Start();
+        Assert.False(recovered.Iteration());
     }
 }

--- a/twodog.tests/Engine/EngineRunTests.cs
+++ b/twodog.tests/Engine/EngineRunTests.cs
@@ -19,7 +19,7 @@ public class EngineRunTests
         AssemblyPreloader.PreloadGameAssemblies(projectDir);
 
         using var engine = new Engine("run-loop", args: ["--headless"]);
-        using var godot = engine.Start();
+        engine.Start();
 
         var frames = 0;
         var framesProcessedAtFirstCallback = 0UL;
@@ -37,7 +37,7 @@ public class EngineRunTests
 
             if (frames == 3)
             {
-                engine.Tree.Quit();
+                engine.RequestQuit();
             }
         });
 
@@ -53,5 +53,71 @@ public class EngineRunTests
     {
         using var engine = new Engine("run-unstarted", Engine.ResolveProjectDir(), "--headless");
         Assert.Throws<InvalidOperationException>(() => engine.Run());
+    }
+
+    [Fact]
+    public void Run_RejectsNestedPumps_AndDisposalFromPerFrameStopsTheLoop()
+    {
+        var projectDir = Engine.ResolveProjectDir();
+        AssemblyPreloader.PreloadGameAssemblies(projectDir);
+        using var engine = new Engine("nested-pump", projectDir, "--headless");
+        engine.Start();
+        var frames = 0;
+        engine.Run(() =>
+        {
+            frames++;
+            Assert.Throws<InvalidOperationException>(() => engine.Run());
+            Assert.Throws<InvalidOperationException>(() => engine.Iteration());
+            engine.Dispose();
+        });
+        Assert.Equal(1, frames);
+        Assert.True(engine.Completion.IsCompletedSuccessfully);
+    }
+
+    [Fact]
+    public void Dispose_FromNativeFrame_DefersDestructionUntilTheFrameReturns()
+    {
+        var projectDir = Engine.ResolveProjectDir();
+        AssemblyPreloader.PreloadGameAssemblies(projectDir);
+        using var engine = new Engine("dispose-in-frame", projectDir, "--headless");
+        engine.Start();
+        var callbackRan = false;
+        var completedInsideFrame = false;
+        var treeSurvived = false;
+        engine.Tree.ProcessFrame += () =>
+        {
+            if (callbackRan) return;
+            callbackRan = true;
+            engine.Dispose();
+            completedInsideFrame = engine.Completion.IsCompleted;
+            treeSurvived = Godot.GodotObject.IsInstanceValid(engine.Tree.Root);
+        };
+
+        Assert.True(engine.Iteration());
+        Assert.True(callbackRan);
+        Assert.False(completedInsideFrame);
+        Assert.True(treeSurvived);
+        Assert.True(engine.Completion.IsCompletedSuccessfully);
+    }
+
+    [Fact]
+    public void Lifecycle_RejectsForeignThreadBeforeTouchingNativeState()
+    {
+        var projectDir = Engine.ResolveProjectDir();
+        AssemblyPreloader.PreloadGameAssemblies(projectDir);
+        using var engine = new Engine("thread-affinity", projectDir, "--headless");
+        engine.Start();
+        Exception? iterateFailure = null;
+        Exception? disposeFailure = null;
+        var thread = new Thread(() =>
+        {
+            iterateFailure = Record.Exception(() => engine.Iteration());
+            disposeFailure = Record.Exception(() => engine.Dispose());
+        });
+        thread.Start();
+        Assert.True(thread.Join(TimeSpan.FromSeconds(10)));
+        Assert.IsType<InvalidOperationException>(iterateFailure);
+        Assert.IsType<InvalidOperationException>(disposeFailure);
+        Assert.False(engine.Iteration());
     }
 }

--- a/twodog.tests/Engine/GodotEditorTests.cs
+++ b/twodog.tests/Engine/GodotEditorTests.cs
@@ -148,7 +148,7 @@ public class GodotEditorTests(HeadlessFixture godot)
         Assert.True(readyCalled);
 
         node.QueueFree();
-        godot.GodotInstance.Iteration();
+        godot.Engine.Iteration();
     }
 
     [Fact]
@@ -159,13 +159,13 @@ public class GodotEditorTests(HeadlessFixture godot)
         godot.Tree.Root.AddChild(node);
 
         for (var i = 0; i < 5; i++)
-            godot.GodotInstance.Iteration();
+            godot.Engine.Iteration();
 
         var count = (int)node.Get("ProcessCount");
         Assert.True(count >= 5);
 
         node.QueueFree();
-        godot.GodotInstance.Iteration();
+        godot.Engine.Iteration();
     }
 }
 #endif

--- a/twodog.tests/Engine/GodotEngineTests.cs
+++ b/twodog.tests/Engine/GodotEngineTests.cs
@@ -45,7 +45,7 @@ public class GodotEngineTests(HeadlessFixture godot)
     public void Iteration_AdvancesFrameCount()
     {
         var before = Godot.Engine.GetProcessFrames();
-        godot.GodotInstance.Iteration();
+        godot.Engine.Iteration();
         var after = Godot.Engine.GetProcessFrames();
 
         Assert.True(after > before);
@@ -54,7 +54,7 @@ public class GodotEngineTests(HeadlessFixture godot)
     [Fact]
     public void Iteration_ReturnsFalse_WhenNotQuitting()
     {
-        var result = godot.GodotInstance.Iteration();
+        var result = godot.Engine.Iteration();
         Assert.False(result);
     }
 

--- a/twodog.tests/Engine/GodotNodeTests.cs
+++ b/twodog.tests/Engine/GodotNodeTests.cs
@@ -28,7 +28,7 @@ public class GodotNodeTests(HeadlessFixture godot)
         Assert.Equal(1, parent.GetChildCount());
 
         parent.QueueFree();
-        godot.GodotInstance.Iteration();
+        godot.Engine.Iteration();
     }
 
     [Fact]
@@ -42,7 +42,7 @@ public class GodotNodeTests(HeadlessFixture godot)
         Assert.Equal(parent, child.GetParent());
 
         parent.QueueFree();
-        godot.GodotInstance.Iteration();
+        godot.Engine.Iteration();
     }
 
     [Fact]
@@ -59,7 +59,7 @@ public class GodotNodeTests(HeadlessFixture godot)
 
         child.Free();
         parent.QueueFree();
-        godot.GodotInstance.Iteration();
+        godot.Engine.Iteration();
     }
 
     [Fact]
@@ -76,7 +76,7 @@ public class GodotNodeTests(HeadlessFixture godot)
         Assert.Equal(childB, parent.GetChild(1));
 
         parent.QueueFree();
-        godot.GodotInstance.Iteration();
+        godot.Engine.Iteration();
     }
 
     [Fact]
@@ -89,7 +89,7 @@ public class GodotNodeTests(HeadlessFixture godot)
         Assert.Contains("PathTest", (string)path);
 
         node.QueueFree();
-        godot.GodotInstance.Iteration();
+        godot.Engine.Iteration();
     }
 
     [Fact]
@@ -102,7 +102,7 @@ public class GodotNodeTests(HeadlessFixture godot)
         Assert.True(node.IsInsideTree());
 
         node.QueueFree();
-        godot.GodotInstance.Iteration();
+        godot.Engine.Iteration();
     }
 
     [Fact]
@@ -118,7 +118,7 @@ public class GodotNodeTests(HeadlessFixture godot)
         Assert.Contains(node, nodesInGroup);
 
         node.QueueFree();
-        godot.GodotInstance.Iteration();
+        godot.Engine.Iteration();
     }
 
     [Fact]
@@ -128,7 +128,7 @@ public class GodotNodeTests(HeadlessFixture godot)
         godot.Tree.Root.AddChild(node);
 
         node.QueueFree();
-        godot.GodotInstance.Iteration();
+        godot.Engine.Iteration();
 
         var found = godot.Tree.Root.FindChild("ToBeFreed");
         Assert.Null(found);
@@ -147,7 +147,7 @@ public class GodotNodeTests(HeadlessFixture godot)
 
         original.QueueFree();
         copy.QueueFree();
-        godot.GodotInstance.Iteration();
+        godot.Engine.Iteration();
     }
 
     [Fact]

--- a/twodog.tests/Engine/GodotPhysicsTests.cs
+++ b/twodog.tests/Engine/GodotPhysicsTests.cs
@@ -87,6 +87,6 @@ public class GodotPhysicsTests(HeadlessFixture godot)
         Assert.True(body.IsInsideTree());
 
         body.QueueFree();
-        godot.GodotInstance.Iteration();
+        godot.Engine.Iteration();
     }
 }

--- a/twodog.tests/Engine/GodotRestartTests.cs
+++ b/twodog.tests/Engine/GodotRestartTests.cs
@@ -80,7 +80,7 @@ public abstract class GodotRestartSmokeTests(HeadlessFixture godot)
     public void MainLoop_Iterates()
     {
         // Iteration() returns true when the engine wants to quit.
-        Assert.False(godot.GodotInstance.Iteration());
+        Assert.False(godot.Engine.Iteration());
     }
 }
 

--- a/twodog.tests/Engine/GodotSceneTests.cs
+++ b/twodog.tests/Engine/GodotSceneTests.cs
@@ -51,7 +51,7 @@ public class GodotSceneTests(HeadlessFixture godot)
         Assert.IsType<Label>(label);
 
         instance.QueueFree();
-        godot.GodotInstance.Iteration();
+        godot.Engine.Iteration();
     }
 
     [Fact]
@@ -66,7 +66,7 @@ public class GodotSceneTests(HeadlessFixture godot)
         Assert.False(string.IsNullOrEmpty(label.Text));
 
         instance.QueueFree();
-        godot.GodotInstance.Iteration();
+        godot.Engine.Iteration();
     }
 
     [Fact]
@@ -79,7 +79,7 @@ public class GodotSceneTests(HeadlessFixture godot)
         Assert.True(instance.IsInsideTree());
 
         instance.QueueFree();
-        godot.GodotInstance.Iteration();
+        godot.Engine.Iteration();
     }
 
     [Fact]

--- a/twodog.tests/Engine/GodotSignalTests.cs
+++ b/twodog.tests/Engine/GodotSignalTests.cs
@@ -18,7 +18,7 @@ public class GodotSignalTests(HeadlessFixture godot)
         Assert.True(fired);
 
         node.QueueFree();
-        godot.GodotInstance.Iteration();
+        godot.Engine.Iteration();
     }
 
     [Fact]
@@ -52,7 +52,7 @@ public class GodotSignalTests(HeadlessFixture godot)
         Assert.Equal(child, received);
 
         parent.QueueFree();
-        godot.GodotInstance.Iteration();
+        godot.Engine.Iteration();
     }
 
     [Fact]
@@ -73,7 +73,7 @@ public class GodotSignalTests(HeadlessFixture godot)
 
         child.Free();
         parent.QueueFree();
-        godot.GodotInstance.Iteration();
+        godot.Engine.Iteration();
     }
 
     [Fact]
@@ -89,7 +89,7 @@ public class GodotSignalTests(HeadlessFixture godot)
         Assert.True(fired);
 
         node.QueueFree();
-        godot.GodotInstance.Iteration();
+        godot.Engine.Iteration();
     }
 
     [Fact]
@@ -124,6 +124,6 @@ public class GodotSignalTests(HeadlessFixture godot)
         Assert.Equal(3, count);
 
         node.QueueFree();
-        godot.GodotInstance.Iteration();
+        godot.Engine.Iteration();
     }
 }

--- a/twodog.tests/Hosting/DualStartTests.cs
+++ b/twodog.tests/Hosting/DualStartTests.cs
@@ -10,17 +10,16 @@ public sealed class CountingProgram : IEngineProgram
 {
     public int Run(IInstanceContext ctx)
     {
-        var engine = new Engine(ctx.Tag, ctx.ProjectDir, ctx.Args) { NativePath = ctx.NativePath };
-        using var godot = engine.Start();
+        using var engine = new Engine(ctx.Tag, ctx.ProjectDir, ctx.Args) { NativePath = ctx.NativePath };
+        engine.Start();
         ctx.SignalBooted();
         (ctx.State as ManualResetEventSlim)?.Wait(TimeSpan.FromSeconds(30));
         var frames = 0;
         for (var i = 0; i < 60; i++)
         {
-            if (godot.Iteration()) break;
+            if (engine.Iteration()) break;
             frames++;
         }
-        engine.Dispose();
         return frames;
     }
 }
@@ -37,17 +36,16 @@ public sealed class PacedProgram : IEngineProgram
         var barrier = (Barrier)(ctx.State ?? throw new InvalidOperationException("PacedProgram needs a Barrier as State."));
         try
         {
-            var engine = new Engine(ctx.Tag, ctx.ProjectDir, ctx.Args) { NativePath = ctx.NativePath };
-            using var godot = engine.Start();
+            using var engine = new Engine(ctx.Tag, ctx.ProjectDir, ctx.Args) { NativePath = ctx.NativePath };
+            engine.Start();
             ctx.SignalBooted();
             var frames = 0;
             for (var i = 0; i < Frames; i++)
             {
-                if (godot.Iteration()) break;
+                if (engine.Iteration()) break;
                 frames++;
                 if (!barrier.SignalAndWait(TimeSpan.FromSeconds(30))) return -1;
             }
-            engine.Dispose();
             return frames;
         }
         catch


### PR DESCRIPTION
Unify engine shutdown and sequential restart across desktop and Web/Blazor. Harden startup rollback and lifetime resets, fix duplicate script registration, and update hosts, templates, and docs.

Validated Windows/Web builds, 94 engine tests (1 skipped), 4 cancellation tests, and three browser lifetimes. Linux/macOS failure paths were reviewed in source only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies engine lifetime so `Engine` owns the Godot instance on every platform. Previously callers disposed `GodotInstance` before `Engine`; now `Start()` returns a borrowed compatibility handle and `Engine` handles teardown, with `Completion`, `Exited`, and `RequestQuit()` for lifecycle control. Sequential restart after teardown now works consistently across desktop, web, and Blazor, and startup rollback is hardened.

**Migration**
- Replace `godot.Iteration()` with `engine.Iteration()` and drop `godot.Dispose()`.
- Call `engine.RequestQuit()` instead of `SceneTree.Quit()` for graceful shutdown.
- Web hosts must call `engine.Run()` after `Start()` and await `DisposeAsync()` on failure.
- Deployments must pick up the bumped natives revision (4), which carries the lifecycle-capable native build.

**Bug Fixes**
- Startup rollback tears down cleanly when boot fails.
- Fixed duplicate script registration.
- Lifecycle notifications stay ordered through teardown; `Exited` fires before `Completion` completes.
- Shutdown restores the host synchronization context before `Exited` fires, so host awaits after quit don't depend on Godot's stopped frame loop.
- macOS CI retains test output instead of crash dumps and runs intentionally failing startup headless, avoiding hangs.
- Added browser restart smoke and Blazor lifetime cancellation tests to CI.

<sup>Written for commit 669710d37df32748437178f7c3301e0d62998206. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/outfox/2dog/pull/50?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

